### PR TITLE
Create project template

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ We recommend checking the examples in the section above to understand how to use
 
 ### Getting Started
 
-This project uses [Nix flakes]() to manage build dependencies and provide a development shell. We provide a template for you initialize a new Zig based postgres extension project, which allows you to reuse some of the utilities we're using.
+This project uses [Nix flakes](https://nixos.wiki/wiki/Flakes) to manage build dependencies and provide a development shell. We provide a template for you initialize a new Zig based Postgres extension project, which allows you to reuse some of the utilities we're using.
 
 Before getting started we would recommend you to familiarize yourself with the projects setup first. To do so, please start with the [Contributing][#contributing] section.   
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,33 @@ The following sample extensions (ordered from simple to complex) show how to use
 
 ## Docs
 
+
 The reference documentation is available at [here](https://xataio.github.io/pgzx/).
 
 We recommend checking the examples in the section above to understand how to use pgzx. The next sections contain a high-level walkthrough of the most important utilities and how they relate to the Postgres internals.
+
+### Getting Started
+
+This project uses [Nix flakes]() to manage build dependencies and provide a development shell. We provide a template for you initialize a new Zig based postgres extension project, which allows you to reuse some of the utilities we're using.
+
+Before getting started we would recommend you to familiarize yourself with the projects setup first. To do so, please start with the [Contributing][#contributing] section.   
+
+
+WARNING: we're assuming the repository is public here. This is currently not the case and you need a local checkout of pgzx. Create a new folder for your project and run the documented commands as given. Your project folder should be a sibling folder next to the local checkout of pgzx. Initialize the project by changing the path to 'path:../pgzx'
+
+We will create a new project folder for our new extension and initialize the folder using the projects template:
+
+```
+$ mkdir my_extension
+$ cd my_extension
+$ nix flake init -t github:xataio/pgzx
+```
+
+This step will create a working extension named 'my_extension'. The extension exports a hello world function named 'hello()'.
+
+The templates README.md file already contains instructions on how to enter the development shell, build, and test the extension. You can follow the instructions and verify that your setup is functioning. Do not forget to use `pgstop` before quitting the development shell.
+
+Next we want to rename the project to match our extension name. To do so update the file names in the `extension` folder, and replace `my_extension` with you project name in the `README.md`, `build.zig`, `build.zig.zon` and extensions SQL file.
 
 ### Logging and error handling
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,6 @@ This project uses [Nix flakes]() to manage build dependencies and provide a deve
 
 Before getting started we would recommend you to familiarize yourself with the projects setup first. To do so, please start with the [Contributing][#contributing] section.   
 
-
-WARNING: we're assuming the repository is public here. This is currently not the case and you need a local checkout of pgzx. Create a new folder for your project and run the documented commands as given. Your project folder should be a sibling folder next to the local checkout of pgzx. Initialize the project by changing the path to 'path:../pgzx'
-
 We will create a new project folder for our new extension and initialize the folder using the projects template:
 
 ```
@@ -45,7 +42,7 @@ $ nix flake init -t github:xataio/pgzx
 
 This step will create a working extension named 'my_extension'. The extension exports a hello world function named 'hello()'.
 
-The templates README.md file already contains instructions on how to enter the development shell, build, and test the extension. You can follow the instructions and verify that your setup is functioning. Do not forget to use `pgstop` before quitting the development shell.
+The templates [README.md](./nix/templates/init/README.md) file already contains instructions on how to enter the development shell, build, and test the extension. You can follow the instructions and verify that your setup is functioning. Do not forget to use `pgstop` before quitting the development shell.
 
 Next we want to rename the project to match our extension name. To do so update the file names in the `extension` folder, and replace `my_extension` with you project name in the `README.md`, `build.zig`, `build.zig.zon` and extensions SQL file.
 

--- a/nix/templates/init/.envrc
+++ b/nix/templates/init/.envrc
@@ -1,0 +1,15 @@
+: ${XDG_CACHE_HOME:=$HOME/.cache}
+
+hash_source() {
+	echo -n "$PWD"
+	cat flake.nix flake.lock devshell.nix
+}
+
+direnv_layout_dir() {
+	local pwd_hash
+	pwd_hash=$(basename "$PWD")-$(hash_source | shasum | cut -d ' ' -f 1 | head -c 7)
+	echo "$XDG_CACHE_HOME/direnv/layouts/$pwd_hash"
+}
+
+watch_file ./devshell.nix
+use flake

--- a/nix/templates/init/.gitignore
+++ b/nix/templates/init/.gitignore
@@ -1,0 +1,6 @@
+zig-cache/
+zig-out/
+regression.out
+regression.diffs
+results/
+/out

--- a/nix/templates/init/README.md
+++ b/nix/templates/init/README.md
@@ -1,0 +1,43 @@
+My Extension
+============
+
+## Development
+
+1. Start development shell
+
+```
+$ nix develop
+```
+
+2. Relocate the postgres installation into our development environment and create a database.
+
+```
+$ pglocal && pginit
+```
+
+3. Start the local postgres development server
+
+```
+$ pgstart
+```
+
+4. Compile and install the extension into the development server
+
+```
+$ zig build -freference-trace -p $PG_HOME
+...
+
+$ psql -U postgres -c 'CREATE EXTENSION my_extension'
+```
+
+5. Verify extension is working
+
+```
+$ psql -U postgres -c 'SELECT hello()'
+```
+
+6. Stop development server
+
+```
+$ pgstop
+```

--- a/nix/templates/init/README.md
+++ b/nix/templates/init/README.md
@@ -21,7 +21,18 @@ $ pglocal && pginit
 $ pgstart
 ```
 
-4. Compile and install the extension into the development server
+4. Before we can the extension we must update the `build.zig.zon` file and enter the maybe update the URL and hash value. To do so we run `zig build` and copy the hash value from the error message into our `build.zig.zon` file:
+
+```
+$ zig build
+
+Fetch Packages... pgzx... build.zig.zon:13:20: error: url field is missing corresponding hash field
+            .url = "https://github.com/xataio/pgzx/archive/main.tar.gz",
+                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+note: expected .hash = "122097e7141a57b8170ca5288f5514b2b5b27b730a78d2aae7a5f54675ae1614c690",
+```
+
+5. Compile and install the extension into the development server
 
 ```
 $ zig build -freference-trace -p $PG_HOME
@@ -30,13 +41,13 @@ $ zig build -freference-trace -p $PG_HOME
 $ psql -U postgres -c 'CREATE EXTENSION my_extension'
 ```
 
-5. Verify extension is working
+6. Verify extension is working
 
 ```
 $ psql -U postgres -c 'SELECT hello()'
 ```
 
-6. Stop development server
+7. Stop development server
 
 ```
 $ pgstop

--- a/nix/templates/init/build.zig
+++ b/nix/templates/init/build.zig
@@ -1,0 +1,46 @@
+const std = @import("std");
+
+// Load pgzx build support. The build utilities use pg_config to find all dependencies
+// and provide functions go create and test extensions.
+const PGBuild = @import("pgzx").Build;
+
+pub fn build(b: *std.Build) void {
+    // Project meta data
+    const name = "my_extension";
+    const version = .{ .major = 0, .minor = 1 };
+
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    // Load the pgzx module and initialize the build utilities
+    const dep_pgzx = b.dependency("pgzx", .{ .target = target, .optimize = optimize });
+    const pgzx = dep_pgzx.module("pgzx");
+    var pgbuild = PGBuild.create(b, .{ .target = target, .optimize = optimize });
+
+    // Register the dependency with the build system
+    // and add pgzx as module dependency.
+    const ext = pgbuild.addInstallExtension(.{
+        .name = name,
+        .version = version,
+        .root_source_file = .{
+            .path = "src/main.zig",
+        },
+        .root_dir = ".",
+    });
+    ext.lib.root_module.addImport("pgzx", pgzx);
+    b.getInstallStep().dependOn(&ext.step);
+
+    // Configure pg_regress based testing for the current extension.
+    const extest = pgbuild.addRegress(.{
+        .db_user = "postgres",
+        .db_port = 5432,
+        .root_dir = ".",
+        .scripts = &[_][]const u8{
+            "char_count_test",
+        },
+    });
+
+    // Make regression tests available to `zig build`
+    var regress = b.step("pg_regress", "Run regression tests");
+    regress.dependOn(&extest.step);
+}

--- a/nix/templates/init/build.zig.zon
+++ b/nix/templates/init/build.zig.zon
@@ -1,0 +1,18 @@
+.{
+    .name = "my_extension",
+    .version = "0.1.0",
+    .paths = .{
+        "extension",
+        "src",
+    },
+    .dependencies = .{
+        .pgzx = .{
+            .path = "./../pgzx",
+
+            // TODO: Use downlaod URL with hash:
+            // .url = "..."
+            // .hash = "..."
+
+        },
+    },
+}

--- a/nix/templates/init/build.zig.zon
+++ b/nix/templates/init/build.zig.zon
@@ -7,12 +7,8 @@
     },
     .dependencies = .{
         .pgzx = .{
-            .path = "./../pgzx",
-
-            // TODO: Use downlaod URL with hash:
-            // .url = "..."
+            .url = "https://github.com/xataio/pgzx/archive/main.tar.gz",
             // .hash = "..."
-
         },
     },
 }

--- a/nix/templates/init/devshell.nix
+++ b/nix/templates/init/devshell.nix
@@ -1,0 +1,60 @@
+{
+  pkgs,
+  lib,
+  project,
+  ...
+}: let
+  menu = ''
+    My Postgres Extension Development Environment
+    =============================================
+
+    Available commands:
+      menu        - Show this menu
+      pglocal     - Relocate the local Postgres installation to the project's out folder
+      pginit      - Initialize the local Postgres installation
+      pgstart     - Start the local Postgres installation
+      pgstop      - Stop the local Postgres installation
+      pgstatus    - Show the run status of the local Postgres installation
+  '';
+
+  makeScripts = scripts:
+    lib.mapAttrsToList
+    (name: script: pkgs.writeShellScriptBin name script)
+    scripts;
+
+  scripts = makeScripts {
+    menu = ''
+      cat <<EOF
+      ${menu}
+      EOF
+    '';
+  };
+in {
+  # Make project build dependencies available to the shell
+  inputsFrom = [project];
+
+  packages =
+    scripts
+    ++ [
+      # Get pgzx development scripts like pglocal, pginit, pgstart...
+      # We also need a local postgres for pglocal that we install in the devshell.
+      pkgs.pgzx_scripts
+      pkgs.postgresql_16_jit
+
+      # Additional Zig tools.
+      pkgs.zls # Zig Language Server
+    ];
+
+  # On shell startup we must set some environment variables for the pgzx scripts:
+  shellHook = ''
+    export PRJ_ROOT=$PWD
+    export PG_HOME=$PRJ_ROOT/out/default
+    export PATH="$PG_HOME/lib/postgresql/pgxs/src/test/regress:$PATH"
+    export PATH="$PG_HOME/bin:$PRJ_ROOT/dev/scripts:$PATH"
+    export NIX_PGLIBDIR=$PG_HOME/lib
+
+    alias root='cd $PRJ_ROOT'
+
+    menu
+  '';
+}

--- a/nix/templates/init/extension/my_extension--0.1.sql
+++ b/nix/templates/init/extension/my_extension--0.1.sql
@@ -1,0 +1,5 @@
+\echo Use "CREATE EXTENSION my_extension" to load this file. \quit
+CREATE FUNCTION hello() RETURNS TEXT
+AS '$libdir/my_extension'
+LANGUAGE C IMMUTABLE
+

--- a/nix/templates/init/extension/my_extension.control
+++ b/nix/templates/init/extension/my_extension.control
@@ -1,0 +1,5 @@
+# my_extension extension
+comment = 'My extension short doc'
+default_version = '0.1'
+module_pathname = '$libdir/my_extension'
+relocatable = true

--- a/nix/templates/init/flake.nix
+++ b/nix/templates/init/flake.nix
@@ -1,0 +1,107 @@
+{
+  description = "Description for the project";
+
+  # Inputs are the flake references that are used in the flake.
+  # Nix will fetch the flake and stores the hash in the flake.lock file.
+  inputs = {
+    # Nixpkgs provides the many packags that are normally available in NixOS.
+    #
+    # WARNING:
+    # We currently pin the verion to 0.2311.555610 to ensure that the zig build
+    # works correctly. Recent updates to nixpkgs did introduce breaking changes to
+    # the build environemnt variables, which makes the Zig compiler fail.
+    #
+    # Issue: https://github.com/ziglang/zig/issues/18998
+    # When resolves remove the '=' from the URL to update to the latest stable
+    # version of nixpkgs.
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/=0.2311.555610.tar.gz";
+
+    # Flake parts is a library to write flakes in a more modular way similar to
+    # NixOS modules.
+    parts.url = "github:hercules-ci/flake-parts";
+
+    # pgzx flake provides us with extra tools and a supported version of the Zig compiler.
+    # The flake re-exports the zig-overlay and zls flakes.
+    pgzx = {
+      url = "git+ssh://git@github.com/xataio/pgzx";
+
+      # TODO: Use correct address when repo goes public
+      # url = "github:xataio/pgzx";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = inputs: let
+    name = "example";
+    version = "0.1";
+  in
+    inputs.parts.lib.mkFlake {inherit inputs;} {
+      # Supported system for which we want to be able to build the project on.
+      systems = ["x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin"];
+
+      perSystem = {
+        config,
+        lib,
+        pkgs,
+        system,
+        ...
+      }: {
+        # Ensure that 'pkgs' has the dependencies from the pgzx flake available.
+        _module.args.pkgs = import inputs.nixpkgs {
+          inherit system;
+          overlays = [
+            inputs.pgzx.overlays.default
+          ];
+          config = {
+            # extra configurations
+            #allowBroken = true;
+            #allowUnfree = true;
+          };
+        };
+
+        # The projects default package is the package that is built when we run `nix build`
+        #
+        # The devshell will import the projects build dependencies.
+        packages.default = pkgs.stdenvNoCC.mkDerivation {
+          pname = name;
+          version = version;
+
+          src = ./.;
+          nativeBuildInputs = [
+            pkgs.zigpkgs.master
+            pkgs.pkg-config
+          ];
+
+          buildInputs = [
+            pkgs.openssl
+          ];
+        };
+
+        devShells.default = let
+          # Load the shell configuration from devshell.nix.
+          userShell = (import ./devshell.nix) {
+            inherit lib pkgs;
+
+            # Pass the default package as project to the devshell. This
+            # allows the devshell to import the project and its dependencies.
+            project = config.packages.default;
+          };
+
+          mkShell = pkgs.mkShell.override {
+            # optionally override the default configuration of the mkShell derivation.
+          };
+        in
+          mkShell (userShell
+            // {
+              # Optionally override or extend the shell configuration.
+              # For example when using the pre-commit-hook module we want to
+              # merge the merge the shell hooks of our flake with the
+              # pre-commit-hook shellHook to ensure the all dependencies are
+              # properly configured when entering the shell.
+              shellHook = ''
+                ${userShell.shellHook or ""}
+              '';
+            });
+      };
+    };
+}

--- a/nix/templates/init/flake.nix
+++ b/nix/templates/init/flake.nix
@@ -23,10 +23,7 @@
     # pgzx flake provides us with extra tools and a supported version of the Zig compiler.
     # The flake re-exports the zig-overlay and zls flakes.
     pgzx = {
-      url = "git+ssh://git@github.com/xataio/pgzx";
-
-      # TODO: Use correct address when repo goes public
-      # url = "github:xataio/pgzx";
+      url = "github:xataio/pgzx";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/nix/templates/init/src/main.zig
+++ b/nix/templates/init/src/main.zig
@@ -1,0 +1,12 @@
+const std = @import("std");
+const pgzx = @import("pgzx");
+
+comptime {
+    pgzx.PG_MODULE_MAGIC();
+
+    pgzx.PG_FUNCTION_V1("hello", hello);
+}
+
+fn hello() ![:0]const u8 {
+    return "Hello, world!";
+}


### PR DESCRIPTION
Add nix flake based project template. This allows downstream users to have a development shell similar to pgzx and reuse some of our scripts. The template create a small functioning hello world based extension (without tests, thought).

The experience is still a little rough because Zig and Nix expect a public repository. For now I made the template so that it works with a local checkout.