### PR TITLE
libpq: common Conn type for sync and async ops

### DIFF
--- a/src/pgzx/c/include/libpqsrv.h
+++ b/src/pgzx/c/include/libpqsrv.h
@@ -18,6 +18,9 @@ pqsrv_connect_params(const char *const *keywords,
 						uint32_t wait_event_info);
 
 void
+pgsrv_wait_connected(void *conn, uint32 wait_event_info);
+
+void
 pqsrv_disconnect(void *conn);
 
 #endif

--- a/src/pgzx/c/libpqsrv.c
+++ b/src/pgzx/c/libpqsrv.c
@@ -25,3 +25,8 @@ void
 pqsrv_disconnect(void *conn)  {
     libpqsrv_disconnect(conn);
 }
+
+void
+pgsrv_wait_connected(void *conn, uint32 wait_event_info) {
+    libpqsrv_connect_internal(conn, wait_event_info);
+}


### PR DESCRIPTION
I found it a little difficult to work with separate types. Let's merge the sync and async interfaces into a common Conn type more similar to libpq.