### PR TITLE
Introduce pgzx unit tests

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -12,37 +12,74 @@ pub fn build(b: *std.Build) void {
     });
 
     // docs step
-    const build_docs = b.addSystemCommand(&[_][]const u8{ "zig", "test", "src/pgzx.zig", "-femit-docs", "-fno-emit-bin" });
-    const docs = b.step("docs", "Generate documentation");
-    docs.dependOn(&build_docs.step);
+    {
+        const build_docs = b.addSystemCommand(&[_][]const u8{ "zig", "test", "src/pgzx.zig", "-femit-docs", "-fno-emit-bin" });
+        const docs = b.step("docs", "Generate documentation");
+        docs.dependOn(&build_docs.step);
+    }
 
     // Reusable modules
-    const pgzx = b.addModule("pgzx", .{
-        .root_source_file = .{ .path = "./src/pgzx.zig" },
-        .target = target,
-        .optimize = optimize,
-    });
-    pgzx.addIncludePath(.{
-        .path = "./src/pgzx/c/include/",
-    });
-    pgzx.addIncludePath(.{
-        .cwd_relative = pgbuild.getIncludeServerDir(),
-    });
-    // libpq support
-    pgzx.addCSourceFiles(.{
-        .files = &[_][]const u8{
-            b.pathFromRoot("./src/pgzx/c/libpqsrv.c"),
-        },
-        .flags = &[_][]const u8{
-            "-I", pgbuild.getIncludeDir(),
-            "-I", pgbuild.getIncludeServerDir(),
-        },
-    });
-    pgzx.addIncludePath(.{
-        .cwd_relative = pgbuild.getIncludeDir(),
-    });
-    pgzx.addLibraryPath(.{
-        .cwd_relative = pgbuild.getLibDir(),
-    });
-    pgzx.linkSystemLibrary("pq", .{});
+    const pgzx = blk: {
+        const module = b.addModule("pgzx", .{
+            .root_source_file = .{ .path = "./src/pgzx.zig" },
+            .target = target,
+            .optimize = optimize,
+        });
+        module.addIncludePath(.{
+            .path = b.pathFromRoot("./src/pgzx/c/include/"),
+        });
+        module.addIncludePath(.{
+            .cwd_relative = pgbuild.getIncludeServerDir(),
+        });
+        // libpq support
+        module.addCSourceFiles(.{
+            .files = &[_][]const u8{
+                b.pathFromRoot("./src/pgzx/c/libpqsrv.c"),
+            },
+            .flags = &[_][]const u8{
+                "-I", pgbuild.getIncludeDir(),
+                "-I", pgbuild.getIncludeServerDir(),
+            },
+        });
+        module.addIncludePath(.{
+            .cwd_relative = pgbuild.getIncludeDir(),
+        });
+        module.addLibraryPath(.{
+            .cwd_relative = pgbuild.getLibDir(),
+        });
+        module.linkSystemLibrary("pq", .{});
+
+        break :blk module;
+    };
+
+    // Unit test extension
+    {
+        const psql_run_tests = pgbuild.addRunTests(.{
+            .name = "pgzx_unit",
+            .db_user = "postgres",
+            .db_port = 5432,
+        });
+
+        const test_options = b.addOptions();
+        test_options.addOption(bool, "testfn", true);
+
+        const test_ext = pgbuild.addInstallExtension(.{
+            .name = "pgzx_unit",
+            .version = .{ .major = 0, .minor = 1 },
+            .root_source_file = .{
+                .path = "src/testing.zig",
+            },
+            .root_dir = "src/testing",
+        });
+        test_ext.lib.root_module.addIncludePath(.{
+            .path = b.pathFromRoot("./src/pgzx/c/include/"),
+        });
+        test_ext.lib.root_module.addImport("pgzx", pgzx);
+        test_ext.lib.root_module.addOptions("build_options", test_options);
+
+        psql_run_tests.step.dependOn(&test_ext.step);
+
+        var unit = b.step("unit", "Run pgzx unit tests");
+        unit.dependOn(&psql_run_tests.step);
+    }
 }

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -1,26 +1,31 @@
 #!/usr/bin/env bash
 
-set -x
+#set -x
 set -o pipefail
 
+test_pgzx() {
+  rc=0
+  run_unit_tests ./ || rc=1
+  extension_drop pgzx_unit
+  return $rc
+}
+
 test_char_count_zig() {
-  echo "Create extension"
   extension_create char_count_zig
   trap "extension_drop char_count_zig" INT TERM
 
-  echo "Run regression tests"
-  run_regression_tests ./examples/char_count_zig
-
-  echo "Run unit tests"
-  run_unit_tests ./examples/char_count_zig
+  rc=0
+  run_regression_tests ./examples/char_count_zig || rc=1
+  run_unit_tests ./examples/char_count_zig || rc=1
 
   extension_drop char_count_zig
+  return $rc
 }
 
 test_pgaudit_zig() {
-  echo "Run unit tests"
   run_unit_tests ./examples/pgaudit_zig
 }
+
 
 extension_build() {
   cwd=$(pwd)
@@ -30,25 +35,46 @@ extension_build() {
 }
 
 extension_create() {
+  echo "Create extension $1"
   psql -U postgres -c "CREATE EXTENSION IF NOT EXISTS $1"
 }
 
 extension_drop() {
+  echo "Drop extension $1"
   psql -U postgres -c "DROP EXTENSION IF EXISTS $1"
 }
 
 run_regression_tests() {
+  echo "Run regression tests"
+  rc=0
+
   cwd=$(pwd)
   cd $1
-  zig build pg_regress --verbose
+  zig build pg_regress --verbose || rc=1
   cd $cwd
+
+  return $rc
 }
 
 run_unit_tests() {
+  echo "Run unit tests"
+  rc=0
+
   cwd=$(pwd)
   cd $1
-  zig build -freference-trace -p $PG_HOME unit
+  zig build -freference-trace -p $PG_HOME unit || rc=1
   cd $cwd
+
+  return $rc
+}
+
+run_test_suites() {
+  for t in "$@"; do
+    echo "# Run $t"
+    if ! $t; then
+      return 1
+    fi
+  done
 }
 
 fail () {
@@ -58,6 +84,13 @@ fail () {
 
 main() {
   echo "Build and install extension"
+  eval $(pgenv)
+
+  log_init_size=0;
+  if [ -f $PG_CLUSTER_LOG_FILE ]; then
+    log_init_size=$(stat -c %s $PG_CLUSTER_LOG_FILE)
+  fi
+  echo "Server log size: $log_init_size"
 
   extension_build ./examples/char_count_zig || fail "Failed to build char_count_zig"
   extension_build ./examples/pgaudit_zig || fail "Failed to build pgaudit_zig"
@@ -66,14 +99,15 @@ main() {
   pgstart || fail "Failed to start PostgreSQL"
   trap pgstop TERM INT EXIT
 
-  ok=1
-  test_char_count_zig || ok=0
 
-  if [ $ok -eq 0 ]; then
+  ok=true
+  run_test_suites test_pgzx test_char_count_zig || ok=false
+
+  if ! $ok; then
     echo "\n\nServer log:"
 
-    eval $(pgenv)
-    cat $PG_CLUSTER_LOG_FILE
+    log_size=$(stat -c %s $PG_CLUSTER_LOG_FILE)
+    tail -c $((log_size - log_init_size)) $PG_CLUSTER_LOG_FILE
     fail "Regression tests failed"
   fi
 

--- a/src/pgzx.zig
+++ b/src/pgzx.zig
@@ -23,8 +23,10 @@ pub const spi = @import("pgzx/spi.zig");
 pub const str = @import("pgzx/str.zig");
 pub const utils = @import("pgzx/utils.zig");
 pub const intr = @import("pgzx/interrupts.zig");
-pub const list = @import("pgzx/list.zig");
 pub const testing = @import("pgzx/testing.zig");
+
+// data structures
+pub const collections = @import("pgzx/collections.zig");
 
 pub const guc = utils.guc;
 
@@ -35,4 +37,5 @@ pub const PG_MODULE_MAGIC = fmgr.PG_MODULE_MAGIC;
 pub const PG_FUNCTION_V1 = fmgr.PG_FUNCTION_V1;
 pub const PG_FUNCTION_INFO_V1 = fmgr.PG_FUNCTION_INFO_V1;
 
+pub const list = collections.list;
 pub const PointerListOf = list.PointerListOf;

--- a/src/pgzx/collections.zig
+++ b/src/pgzx/collections.zig
@@ -1,0 +1,3 @@
+pub const list = @import("collections/list.zig");
+pub const slist = @import("collections/slist.zig");
+pub const dlist = @import("collections/dlist.zig");

--- a/src/pgzx/collections/slist.zig
+++ b/src/pgzx/collections/slist.zig
@@ -1,0 +1,116 @@
+//! Postgres intrusive singly linked list support.
+
+const std = @import("std");
+
+const c = @import("../c.zig");
+
+fn initNode() c.slist_node {
+    return .{ .next = null };
+}
+
+pub fn SList(comptime T: type, comptime node_field: std.meta.FieldEnum(T)) type {
+    return struct {
+        head: c.slist_head,
+
+        const Self = @This();
+        usingnamespace SListMeta(T, node_field);
+
+        const Iterator = SListIter(T, node_field);
+
+        pub fn init() Self {
+            var h = Self{};
+            c.slist_init(&h.head);
+            return h;
+        }
+
+        pub fn initWith(init_head: c.slist_head) Self {
+            return Self{ .head = init_head };
+        }
+
+        pub fn initFrom(init_node: *T) Self {
+            var l = Self.init();
+            l.head.head.next = Self.nodePtr(init_node);
+            return l;
+        }
+
+        pub fn isEmpty(self: *const Self) bool {
+            return c.slist_empty(&self.head);
+        }
+
+        pub fn prepend(self: *Self, v: *T) void {
+            c.slist_push_head(&self.head, Self.nodePtr(v));
+        }
+
+        pub fn popFront(self: *Self) ?*T {
+            const node_ptr = c.slist_pop_head(&self.head);
+            return Self.optNodeParentPtr(node_ptr);
+        }
+
+        pub fn head(self: *Self) ?*T {
+            const node_ptr = c.slist_head_node(&self.head);
+            return Self.optNodeParentPtr(node_ptr);
+        }
+
+        pub fn tail(self: *Self) ?*T {
+            const node_ptr = c.slist_tail_node(&self.head);
+            if (node_ptr == null) return null;
+
+            var new_head: c.slit_head = undefined;
+            new_head.head.next = node_ptr;
+            return Self.initWith(new_head);
+        }
+
+        pub fn insertAfter(prev: *T, v: *T) void {
+            c.slist_insert_after(Self.nodePtr(prev), Self.nodePtr(v));
+        }
+
+        pub fn hasNext(v: *T) bool {
+            return Self.nodePtr(v).*.next != null;
+        }
+
+        pub fn next(v: *T) ?*T {
+            const node_ptr = c.slist_next(Self.nodePtr(v));
+            return Self.optNodeParentPtr(node_ptr);
+        }
+
+        pub fn iter(self: *Self) Iterator {
+            var i: c.slist_iter = undefined;
+            i.cur = Self.nodePtr(self.head.head.next);
+            return .{ .iter = i };
+        }
+    };
+}
+
+pub fn SListIter(comptime T: type, comptime node_field: std.meta.FieldEnum(T)) type {
+    return struct {
+        const Self = @This();
+        usingnamespace SListMeta(T, node_field);
+
+        iter: c.slist_iter,
+
+        pub fn next(self: *Self) ?*T {
+            const node_ptr = c.slist_next(&self.node);
+            return if (node_ptr) |p| Self.nodeParentPtr(p) else null;
+        }
+    };
+}
+
+fn SListMeta(comptime T: type, comptime node_field: std.meta.FieldEnum(T)) type {
+    return struct {
+        const node = @TypeOf(T).fieldInfo(node_field).name;
+
+        fn nodePtr(v: *T) *c.slist_node {
+            return &@field(v, node);
+        }
+
+        fn nodeParentPtr(n: *c.slist_node) ?*T {
+            return @fieldParentPtr(T, node, n);
+        }
+
+        fn optNodeParentPtr(n: ?*c.slist_node) ?*T {
+            return if (n) |p| nodeParentPtr(p) else null;
+        }
+    };
+}
+
+pub const TestSuite = struct {};

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -1,0 +1,12 @@
+const pgzx = @import("pgzx.zig");
+
+comptime {
+    pgzx.PG_MODULE_MAGIC();
+
+    pgzx.testing.registerTests(
+        @import("build_options").testfn,
+        .{
+            pgzx.collections.list.PointerListTestSuite,
+        },
+    );
+}

--- a/src/testing/extension/pgzx_unit.control
+++ b/src/testing/extension/pgzx_unit.control
@@ -1,0 +1,5 @@
+# pgzx_unit testing extension
+comment = 'PGZX unit tests'
+default_version = '0.1'
+module_pathname = '$libdir/pgzx_unit'
+relocatable = false


### PR DESCRIPTION
Introduce the `pgzx_unit` extension that is used to execute pgzx specific unit tests in Postgres.

The extensions entrypoint is `src/testing.zig`. Here we register all test suites that will later be run by the `./ci/run.sh` script. We basically use the same mechanism that we use for normal extensions code.

As I'm currently in need for the collection types I added some tests for the already implemented `List` type. slist, dlist and hashtables will be follow up work.

Other changes:
- Use code blocks in `build.zig` to better "isolate" doc build, test build, and the module definition.
- some fixes to ./ci/run.sh. Now we correctly fail early on errors and only print new logs (since beginning of our tests) on errors
- moved `pgzx.list` to `pgzx.collections.list`. We still have a `pgzx.list` alias for convenience.
- applied some fixes to the PointerList implementation to make sure that the constructors compile.
- initial implementation for slist support sneaked in somehow 🤷  

