### PR TITLE
Export `meta` module.

### DIFF
--- a/src/pgzx.zig
+++ b/src/pgzx.zig
@@ -41,4 +41,8 @@ pub const utils = @import("pgzx/utils.zig");
 pub const intr = @import("pgzx/interrupts.zig");
 pub const testing = @import("pgzx/testing.zig");
 
+// reexport the meta module. Although quite generic, it is useful to have these
+// helpers around at times.
+pub const meta = @import("pgzx/meta.zig");
+
 pub const guc = utils.guc;

--- a/src/pgzx/meta.zig
+++ b/src/pgzx/meta.zig
@@ -32,3 +32,10 @@ pub inline fn isPrimitive(comptime T: type) bool {
         else => false,
     };
 }
+
+pub inline fn fnReturnType(comptime T: type, comptime fnName: []const u8) type {
+    return switch (@typeInfo(@field(T, fnName))) {
+        .Fn => |f| f.return_type.?,
+        else => @compileError("Expected a function type"),
+    };
+}


### PR DESCRIPTION
Depends on #22 

I found the helpers in `meta` to be useful in downstream code. For now I'm exporting it under `pgzx.meta`. I wonder if we eventually want to introduce a `pgzx.lib` namespace for common utility functions that are not directly related to Postgres code.