### PR TITLE
  rename: iter -> iterator 

### DIFF
--- a/examples/pgaudit_zig/README.md
+++ b/examples/pgaudit_zig/README.md
@@ -258,7 +258,7 @@ The `executorCheckPermsHook` function receives the list of tables (`rangeTable`)
 
 
 ```zig
-    var it = pgzx.PointerListOf(pg.RangeTblEntry).init(rangeTables).iter();
+    var it = pgzx.PointerListOf(pg.RangeTblEntry).init(rangeTables).iterator();
     while (it.next()) |rte| {
         ...
     }

--- a/examples/pgaudit_zig/src/main.zig
+++ b/examples/pgaudit_zig/src/main.zig
@@ -153,7 +153,7 @@ fn executorCheckPermsHook(rangeTables: [*c]pg.List, rtePermInfos: [*c]pg.List, v
     var errctx = pgzx.err.Context.init();
     defer errctx.deinit();
     if (errctx.pg_try()) {
-        var it = pgzx.PointerListOf(pg.RangeTblEntry).initFrom(rangeTables).iter();
+        var it = pgzx.PointerListOf(pg.RangeTblEntry).initFrom(rangeTables).iterator();
         while (it.next()) |rte| {
             const relOid = rte.?.relid;
             const relNamespaceOid = pg.get_rel_namespace(relOid);

--- a/src/pgzx/collections/dlist.zig
+++ b/src/pgzx/collections/dlist.zig
@@ -75,7 +75,7 @@ pub fn DList(comptime T: type, comptime node_field: std.meta.FieldEnum(T)) type 
 
         pub inline fn count(self: *const Self) usize {
             var n: usize = 0;
-            var it = self.iter();
+            var it = self.iterator();
             while (it.next() != null) : (n += 1) {}
             return n;
         }
@@ -140,7 +140,7 @@ pub fn DList(comptime T: type, comptime node_field: std.meta.FieldEnum(T)) type 
             return descr.nodeParentPtr(c.dlist_prev_node(&self.list, descr.nodePtr(node)));
         }
 
-        pub inline fn iter(self: *const Self) Iterator {
+        pub inline fn iterator(self: *const Self) Iterator {
             return Iterator.init(&self.list);
         }
 
@@ -242,7 +242,7 @@ pub const TestSuite_DList = struct {
         var list = TList.init();
         try std.testing.expectEqual(true, list.isEmpty());
 
-        var it = list.iter();
+        var it = list.iterator();
         while (it.next()) |n| {
             _ = n;
             std.log.info("iterating over empty list", .{});
@@ -279,7 +279,7 @@ pub const TestSuite_DList = struct {
         try std.testing.expectEqual(3, list.count());
 
         var i: u32 = 0;
-        var it = list.iter();
+        var it = list.iterator();
         while (it.next()) |n| {
             i += 1;
             try std.testing.expect(i <= 3);
@@ -301,7 +301,7 @@ pub const TestSuite_DList = struct {
         try std.testing.expectEqual(3, list.count());
 
         var i: u32 = 3;
-        var it = list.iter();
+        var it = list.iterator();
         while (it.next()) |n| {
             try std.testing.expect(i >= 1);
             try std.testing.expectEqual(i, n.value);

--- a/src/pgzx/collections/htab.zig
+++ b/src/pgzx/collections/htab.zig
@@ -196,7 +196,7 @@ pub fn HTab(comptime Context: type) type {
 
         /// Initialize an iterator for the hash table.
         /// If the iterator was not full exhausted, it should be terminated with `term`.
-        pub fn iter(self: Self) Iterator {
+        pub fn iterator(self: Self) Iterator {
             return Iterator.init(self.htab);
         }
 
@@ -564,7 +564,7 @@ pub const TestSuite_HTab = struct {
         try table.put(&k2, 25);
 
         var count: u32 = 0;
-        var iter = table.iter();
+        var iter = table.iterator();
         while (iter.next()) |_| {
             count += 1;
         }

--- a/src/pgzx/collections/list.zig
+++ b/src/pgzx/collections/list.zig
@@ -106,7 +106,7 @@ pub fn PointerListOf(comptime T: type) type {
             return c.list_length(self.list);
         }
 
-        pub fn iter(self: Self) Iterator {
+        pub fn iterator(self: Self) Iterator {
             return Iterator.init(self.list);
         }
 
@@ -242,7 +242,7 @@ pub const TestSuite_PointerList = struct {
         var list = PointerListOf(i32).init();
         defer list.deinit();
 
-        var it = list.iter();
+        var it = list.iterator();
         try std.testing.expect(it.next() == null);
     }
 
@@ -258,7 +258,7 @@ pub const TestSuite_PointerList = struct {
         list.append(@constCast(&elems[5]));
         defer list.deinit();
 
-        var it = list.iter();
+        var it = list.iterator();
         var i: i32 = 1;
         while (it.next()) |elem| {
             try std.testing.expect(i <= 6);

--- a/src/pgzx/collections/slist.zig
+++ b/src/pgzx/collections/slist.zig
@@ -75,7 +75,7 @@ pub fn SList(comptime T: type, comptime node_field: std.meta.FieldEnum(T)) type 
             return Self.optNodeParentPtr(node_ptr);
         }
 
-        pub inline fn iter(self: *Self) Iterator {
+        pub inline fn iterator(self: *Self) Iterator {
             var i: c.slist_iter = undefined;
             i.cur = self.head.head.next;
             return .{ .iter = i };
@@ -128,7 +128,7 @@ pub const TestSuite_SList = struct {
         var list = MyList.init();
         try std.testing.expect(list.isEmpty());
 
-        var it = list.iter();
+        var it = list.iterator();
         try std.testing.expect(it.next() == null);
 
         try std.testing.expect(list.headNode() == null);
@@ -150,7 +150,7 @@ pub const TestSuite_SList = struct {
         list.pushHead(&values[0]);
 
         var i: u32 = 1;
-        var it = list.iter();
+        var it = list.iterator();
         while (it.next()) |node| {
             try std.testing.expect(i <= 3);
             try std.testing.expect(node.*.value == i);
@@ -179,7 +179,7 @@ pub const TestSuite_SList = struct {
         _ = list.popHead();
 
         var i: u32 = 2;
-        var it = list.iter();
+        var it = list.iterator();
         while (it.next()) |node| {
             try std.testing.expect(i <= 3);
             try std.testing.expect(node.*.value == i);
@@ -193,7 +193,7 @@ pub const TestSuite_SList = struct {
         _ = list.popHead();
         try std.testing.expect(list.isEmpty());
 
-        it = list.iter();
+        it = list.iterator();
         try std.testing.expect(it.next() == null);
 
         try std.testing.expect(list.headNode() == null);


### PR DESCRIPTION
Requires #22, #23

Rename `iter()` methods to `iterator()`. Zig std lib also uses `iterator()`, which allows me to use different container types downstream.