### PR TITLE
Maintenance: update zig toolchain

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -70,11 +70,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1709126324,
-        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -275,11 +275,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709640506,
-        "narHash": "sha256-KyX0jga/DzLHdO7/W5hmPZ3aOBnQmP77kiuBXh3FaTY=",
+        "lastModified": 1710763758,
+        "narHash": "sha256-cQtWj48P7GtfSCql9C8kpInvXpG3hN5RBh9VZd+SAks=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "94cbbf1d41eaded823d5287513c7c79c980aaf3f",
+        "rev": "d484cf2afa81c1d98de9379132871e32de2cfd41",
         "type": "github"
       },
       "original": {
@@ -301,11 +301,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709575088,
-        "narHash": "sha256-3dIOlxTxCH+bP+AwvvAioUmyvF7zVxpa0DIfKVKsGhA=",
+        "lastModified": 1710703275,
+        "narHash": "sha256-1zb0z7NvpyR6KiM7kOcF9Ng0n7mNQViL+N0f88opj6I=",
         "owner": "zigtools",
         "repo": "zls",
-        "rev": "dd307c59bf32e2cec323235c776e07fa36efb465",
+        "rev": "0844c710348301cfd9634044abf153767f8102b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Update zig compiler and zls via 

```
nix flake lock --update-input zig-overlay --update-input zls
```