### PR TITLE
move pgzx.fmgr.conv to pgzx.datum

### DIFF
--- a/src/pgzx.zig
+++ b/src/pgzx.zig
@@ -20,6 +20,8 @@ pub const HTabIter = collections.htab.HTabIter;
 pub const StringHashTable = collections.htab.StringHashTable;
 pub const KVHashTable = collections.htab.KVHashTable;
 
+pub const datum = @import("pgzx/datum.zig");
+
 pub const elog = @import("pgzx/elog.zig");
 
 pub const err = @import("pgzx/err.zig");

--- a/src/pgzx/datum.zig
+++ b/src/pgzx/datum.zig
@@ -1,10 +1,10 @@
 const std = @import("std");
 
-const c = @import("../c.zig");
-const err = @import("../err.zig");
-const mem = @import("../mem.zig");
-const meta = @import("../meta.zig");
-const varatt = @import("../varatt.zig");
+const c = @import("c.zig");
+const err = @import("err.zig");
+const mem = @import("mem.zig");
+const meta = @import("meta.zig");
+const varatt = @import("varatt.zig");
 
 pub fn Conv(comptime T: type, comptime from: anytype, comptime to: anytype) type {
     return struct {
@@ -74,18 +74,18 @@ var directMappings = .{
 };
 
 pub fn fromNullableDatum(comptime T: type, d: c.NullableDatum) !T {
-    return find(T).fromNullableDatum(d);
+    return findConv(T).fromNullableDatum(d);
 }
 
 pub fn fromDatum(comptime T: type, d: c.Datum, is_null: bool) !T {
-    return find(T).fromNullableDatum(.{ .value = d, .isnull = is_null });
+    return findConv(T).fromNullableDatum(.{ .value = d, .isnull = is_null });
 }
 
 pub fn toNullableDatum(v: anytype) !c.NullableDatum {
-    return find(@TypeOf(v)).toNullableDatum(v);
+    return findConv(@TypeOf(v)).toNullableDatum(v);
 }
 
-pub fn find(comptime T: type) type {
+pub fn findConv(comptime T: type) type {
     if (isConv(T)) { // is T already a converter?
         return T;
     }
@@ -124,7 +124,7 @@ pub fn find(comptime T: type) type {
             64 => Float64,
             else => @compileError("unsupported float type"),
         },
-        .Optional => |opt| OptConv(find(opt.child)),
+        .Optional => |opt| OptConv(findConv(opt.child)),
         .Array => @compileLog("fixed size arrays not supported"),
         .Pointer => blk: {
             if (!meta.isStringLike(T)) {

--- a/src/pgzx/fmgr.zig
+++ b/src/pgzx/fmgr.zig
@@ -1,9 +1,10 @@
 const std = @import("std");
 
 const c = @import("c.zig");
-pub const elog = @import("elog.zig");
+const elog = @import("elog.zig");
+const datum = @import("datum.zig");
+
 pub const args = @import("fmgr/args.zig");
-pub const conv = @import("fmgr/conv.zig");
 pub const varatt = c.varatt;
 
 pub const Pg_magic_struct = c.Pg_magic_struct;
@@ -93,7 +94,7 @@ pub inline fn pgCall(
     }
 
     const value = @call(.no_async, impl, callArgs) catch |e| elog.throwAsPostgresError(src, e);
-    const resultConv = conv.find(@TypeOf(value));
+    const resultConv = datum.findConv(@TypeOf(value));
     const nullableDatum = resultConv.toNullableDatum(value) catch |e| elog.throwAsPostgresError(src, e);
     if (nullableDatum.isnull) {
         fcinfo.*.isnull = true;

--- a/src/pgzx/fmgr/args.zig
+++ b/src/pgzx/fmgr/args.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const c = @import("../c.zig");
-const conv = @import("conv.zig");
+const datum = @import("../datum.zig");
 
 /// Index function argument type.
 pub fn Arg(comptime T: type, comptime argNum: u32) type {
@@ -49,7 +49,7 @@ inline fn readArgType(comptime T: type) type {
     if (T == c.FunctionCallInfo) {
         return T;
     }
-    return conv.find(T).Type;
+    return datum.findConv(T).Type;
 }
 
 /// Reads a postgres function call argument as a given type.
@@ -57,7 +57,7 @@ fn readArg(comptime T: type, fcinfo: c.FunctionCallInfo, argNum: u32) !readArgTy
     if (T == c.FunctionCallInfo) {
         return fcinfo;
     }
-    const converter = comptime conv.find(T);
+    const converter = comptime datum.findConv(T);
     return converter.fromNullableDatum(try mustGetArgNullable(fcinfo, argNum));
 }
 


### PR DESCRIPTION
I think the 'datum' converters should become reusable in general. Let's move them into its own top level module and cleanup some module re-exports in fmgr.