### PR TITLE
Package: Add build.zig to list of paths

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,6 +2,7 @@
     .name = "pgzx",
     .version = "0.1.0",
     .paths = .{
+        "build.zig",
         "src",
     },
 }


### PR DESCRIPTION
Add missing `build.zig` file to list of exported paths. This fixes an issue where projects depending on pgzx can not import the pgzx build tools.