### PR TITLE
libpq improvements

### DIFF
--- a/src/pgzx/c/include/libpqsrv.h
+++ b/src/pgzx/c/include/libpqsrv.h
@@ -2,6 +2,7 @@
 #define PGZX_PQSRV_HELPERS
 
 #include <stdint.h>
+#include <libpq-fe.h>
 
 // re-export the `libpqsrv` helper functions.
 // The original functions use C-inline code, but unfortunately the translated
@@ -9,18 +10,16 @@
 
 void pqsrv_connect_prepare(void);
 
-void *pqsrv_connect(const char *conninfo, uint32_t wait_event_info);
+PGconn * pqsrv_connect(const char *conninfo, uint32_t wait_event_info);
 
-void*
-pqsrv_connect_params(const char *const *keywords,
-						const char *const *values,
-						int expand_dbname,
-						uint32_t wait_event_info);
+PGconn* pqsrv_connect_params(
+    const char *const *keywords,
+		const char *const *values,
+		int expand_dbname,
+		uint32_t wait_event_info);
 
-void
-pgsrv_wait_connected(void *conn, uint32 wait_event_info);
+void pgsrv_wait_connected(void *conn, uint32 wait_event_info);
 
-void
-pqsrv_disconnect(void *conn);
+void pqsrv_disconnect(void *conn);
 
 #endif

--- a/src/pgzx/c/libpqsrv.c
+++ b/src/pgzx/c/libpqsrv.c
@@ -8,11 +8,12 @@ void pqsrv_connect_prepare(void) {
     libpqsrv_connect_prepare();
 }
 
-void *pqsrv_connect(const char *conninfo, uint32 wait_event_info) {
+PGconn *
+pqsrv_connect(const char *conninfo, uint32 wait_event_info) {
     return libpqsrv_connect(conninfo, wait_event_info);
 }
 
-void*
+PGconn*
 pqsrv_connect_params(const char *const *keywords,
 						const char *const *values,
 						int expand_dbname,

--- a/src/pgzx/pq/conv.zig
+++ b/src/pgzx/pq/conv.zig
@@ -50,7 +50,7 @@ pub fn find(comptime T: type) type {
                 @compileLog("type:", T);
                 @compileError("unsupported ptr type");
             }
-            break :blk if (meta.isSentinel(T)) textzconv else textconv;
+            break :blk if (meta.hasSentinal(T)) textzconv else textconv;
         },
         else => {
             @compileLog("type:", T);
@@ -172,10 +172,10 @@ const textconv = struct {
 };
 
 const textzconv = struct {
-    const OID = c.TEXTOID;
-    const Type = [:0]const u8;
+    pub const OID = c.TEXTOID;
+    pub const Type = [:0]const u8;
 
-    pub fn write(writer: std.io.Writer, value: [:0]const u8) !void {
+    pub fn write(writer: anytype, value: [:0]const u8) !void {
         _ = try writer.write(value);
     }
 


### PR DESCRIPTION
Requires #37, #38

Use correct types in C helpers instead of `void*`. This also improve the Zig code as we do not have to cast between types and opaque pointer types.

export missing symbol.

Accept const pointers for our wrapper types. This makes it easier to use our wrapper type from within other types.