### PR TITLE
pgzx.mem: Fix, improvements, tests

### DIFF
--- a/examples/pgaudit_zig/src/main.zig
+++ b/examples/pgaudit_zig/src/main.zig
@@ -235,10 +235,9 @@ fn freeEvent(event: *AuditEvent) void {
     memctx.deinit();
 }
 
-fn pgaudit_zig_MemoryContextCallback(arg: ?*anyopaque) callconv(.C) void {
+fn pgaudit_zig_MemoryContextCallback(memctx: pg.MemoryContext) void {
     std.log.debug("pgaudit_zig: MemoryContextCallback\n", .{});
 
-    const memctx: pg.MemoryContext = @alignCast(@ptrCast(arg));
     const list = getAuditList() catch return;
     const event = popEvent(list, memctx) catch |err| {
         if (err == error.EventNotFound) {

--- a/src/pgzx/mem.zig
+++ b/src/pgzx/mem.zig
@@ -53,7 +53,7 @@ fn pg_resize(ctx: *anyopaque, buf: []u8, buf_align: u8, new_len: usize, ret_addr
 }
 
 pub fn getErrorContext() MemoryContextAllocator {
-    return MemoryContextAllocator.init(c.ErrorContext);
+    return MemoryContextAllocator.new(c.ErrorContext);
 }
 
 /// ErrorContext based memory context allocator.

--- a/src/pgzx/testing.zig
+++ b/src/pgzx/testing.zig
@@ -78,7 +78,10 @@ fn runTestSuite(T: anytype) !u32 {
         if (comptime std.mem.startsWith(u8, f.name, "test")) {
             elog.Info(@src(), "Running test: {s}\n", .{f.name});
 
-            try runTestSuiteTest(@field(T, f.name));
+            runTestSuiteTest(@field(T, f.name)) catch |e| {
+                elog.Info(@src(), "FAIL: {s}\n", .{f.name});
+                return e;
+            };
             success_count += 1;
         }
     }

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -12,6 +12,8 @@ comptime {
             pgzx.collections.htab.TestSuite_HTab,
 
             pgzx.meta.TestSuite_Meta,
+
+            pgzx.mem.TestSuite_Mem,
         },
     );
 }


### PR DESCRIPTION
Add `pgzx.mem` unit tests to verify the API compiling/functioning as expected.

Fix `getErrorContext` not compiling.

API changes:
- Use configuration struct pattern to initialize the memory context allocator
- rename `new` to `init` to improve consistency. The methods have been hidden, but still
- improve `registerAllocResetCallback` type safety:
  - rename to `registerAllocResetCallbackFn`
  - introduce new method `registerAllocResetCallback` wrapper method that accepts a properly typed pointer and function doing. The wrapper implements that pointer cast. The function pointer is not required to implement the C calling convention (see `reset` unit test or `pg_audit_zig` updates)