### PR TITLE
Update env: docker and flakes

### DIFF
--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -7,7 +7,8 @@ ARG USERNAME=dev
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
-RUN groupadd --gid $USER_GID $USERNAME \
+RUN userdel -r ubuntu \
+    && groupadd --gid $USER_GID $USERNAME \
     && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME \

--- a/dev/docker/build.sh
+++ b/dev/docker/build.sh
@@ -3,6 +3,9 @@
 set -e
 set -x
 
+IMAGE_NAME=pgzx
+IMAGE_TAG=latest
+
 SCRIPT_DIR=$(
 	cd "$(dirname "$0")"
 	pwd
@@ -11,4 +14,4 @@ PRJ_ROOT=${PRJ_ROOT:-$(realpath "$SCRIPT_DIR/../..")}
 DOCKERFILE=${DOCKERFILE:-"$PRJ_ROOT/dev/docker/Dockerfile"}
 
 cd "$PRJ_ROOT"
-docker build -t pgzx:latest -f "$DOCKERFILE" .
+docker build -t "$IMAGE_NAME:$IMAGE_TAG" -f "$DOCKERFILE" .

--- a/dev/docker/run.sh
+++ b/dev/docker/run.sh
@@ -3,6 +3,9 @@
 set -e
 set -x
 
+IMAGE_NAME=pgzx
+IMAGE_TAG=latest
+
 SCRIPT_DIR=$(
 	cd "$(dirname "$0")"
 	pwd
@@ -12,5 +15,5 @@ PRJ_ROOT=${PRJ_ROOT:-$(realpath "$SCRIPT_DIR/../..")}
 docker run -i -t --rm \
 	-v "$PRJ_ROOT:/home/dev/workdir" \
 	-w /home/dev/workdir \
-	pgzx:latest \
+	"$IMAGE_NAME:$IMAGE_TAG" \
 	"$@"

--- a/flake.lock
+++ b/flake.lock
@@ -128,13 +128,13 @@
     "langref": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-94broSBethRhPJr0G9no4TPyB8ee6BQ/hHK1QnLPln0=",
+        "narHash": "sha256-Kz+m9yeJgAsUfNwGG6ZDqZ3ElLZMeQmVYzgg0EEUzV4=",
         "type": "file",
-        "url": "https://raw.githubusercontent.com/ziglang/zig/54bbc73f8502fe073d385361ddb34a43d12eec39/doc/langref.html.in"
+        "url": "https://raw.githubusercontent.com/ziglang/zig/a685ab1499d6560c523f0dbce2890dc140671e43/doc/langref.html.in"
       },
       "original": {
         "type": "file",
-        "url": "https://raw.githubusercontent.com/ziglang/zig/54bbc73f8502fe073d385361ddb34a43d12eec39/doc/langref.html.in"
+        "url": "https://raw.githubusercontent.com/ziglang/zig/a685ab1499d6560c523f0dbce2890dc140671e43/doc/langref.html.in"
       }
     },
     "nixpkgs": {
@@ -275,11 +275,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713745451,
-        "narHash": "sha256-j5/bimg/wI14yTDUXZcSQRosV1LIOYuxYkZjvVJC/yg=",
+        "lastModified": 1714133353,
+        "narHash": "sha256-oDA4fGiFPxwiLHTJjY2hWn06Dg4yFW+EH/U9FTL8oRY=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "2c86c36e7fe65faac08bdf85d041cf7b798f8ee8",
+        "rev": "751dd89e227c60e89c6362fc5cdd5cb814e3f1ba",
         "type": "github"
       },
       "original": {
@@ -301,11 +301,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713742752,
-        "narHash": "sha256-mVc0Kig80StZd3rLYuDVJ3jvFmEFepJubfzttuBOS48=",
+        "lastModified": 1714213794,
+        "narHash": "sha256-8/tQeR3EV9dc8wIDcAqqaah2IZb039euqdT/R62TN/Q=",
         "owner": "zigtools",
         "repo": "zls",
-        "rev": "07508440588bf06f041da9f6dd3956948368f194",
+        "rev": "4efd646c8458077da64ca589241b7d060996faa7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Update zig toolchain

Update Docker image: Ubuntu images now have a default user `ubuntu`. I tried to update the Dockerfile to use the new user, but didn't get it functioning correctly. Instead for now I opted to delete the `ubuntu` user and keep the `dev` user an environment as is.