### PR TITLE
elog: add XWithCause to include the cause in the error report

### DIFF
--- a/src/pgzx/elog.zig
+++ b/src/pgzx/elog.zig
@@ -287,13 +287,13 @@ fn sendElogWithCause(src: SourceLocation, comptime level: c_int, cause: anyerror
         return;
     }
 
-    const errName = @errorName(cause);
+    const err_name = @errorName(cause);
 
     var memctx = mem.getErrorContextThrowOOM();
-    var buf = std.ArrayList(u8).initCapacity(memctx.allocator(), fmt.len + errName.len + 20) catch unreachable;
+    var buf = std.ArrayList(u8).initCapacity(memctx.allocator(), fmt.len + err_name.len + 20) catch unreachable;
     buf.writer().print(fmt, args) catch unreachable;
     buf.writer().writeAll(": ") catch unreachable;
-    buf.writer().writeAll(errName) catch unreachable;
+    buf.writer().writeAll(err_name) catch unreachable;
     buf.writer().writeByte(0) catch unreachable;
 
     Report.init(src, level).pgRaise(.{ .message = buf.items[0 .. buf.items.len - 1 :0] });


### PR DESCRIPTION
Sometimes we want to log an error after capturing another error.

Postgres errors and warnings are normally added to the error stack (default size 5). The top entry of the error stack can be flushed via `pg.EmitErrorReport`. Due to pgzx capturing errors and returning the `PGStackError` we do not immediately call emit right now.

With this change we introduce `XWithCause` functions to elog, like `LogWithCause`, `ErrorWithCause` and so on. These functions accept an existing Zig error. In case the error given is `PGStackError` we will call `pg.EmitErrorReport` to flush the original error. In case the error is not `PGStackError` we print the the error message and append the error code to the message like so: `<my error message>: <cause>`. This pattern allows us to use the `WithCause` functions with errors we captured using the Postgres API and Zig error codes using the same API. 