### PR TITLE
FDW: accept empty options list (NIL)

### DIFF
--- a/src/pgzx/fdw.zig
+++ b/src/pgzx/fdw.zig
@@ -209,7 +209,7 @@ pub fn listFindOption(list: ?*pg.List, name: []const u8) ?*const DefElem {
     return null;
 }
 
-pub fn validateOptions(list: anytype, options: *pg.List, context: pg.Oid) void {
+pub fn validateOptions(list: anytype, options: ?*pg.List, context: pg.Oid) void {
     var iter = DefElemList.iteratorFrom(options);
     while (iter.next()) |def| {
         const found = list.findAndValidateOption(def.?, context);


### PR DESCRIPTION
Empty list is indicated by `NIL`. We must accept an optional pointer in our Zig callback.