### PR TITLE
pgsys module

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -81,9 +81,12 @@ pub fn build(b: *std.Build) void {
             .link_libc = true,
             .link_allow_shlib_undefined = true,
         });
-        tests.lib.root_module.addIncludePath(b.path("./src/pgzx/c/include/"));
-        tests.lib.root_module.addImport("pgzx", pgzx);
         tests.lib.root_module.addOptions("build_options", test_options);
+
+        tests.lib.root_module.addIncludePath(b.path("./src/pgzx/c/include/"));
+
+        tests.lib.root_module.addImport("pgzx_pgsys", pgzx_pgsys);
+        tests.lib.root_module.addImport("pgzx", pgzx);
 
         break :blk tests;
     };

--- a/build.zig
+++ b/build.zig
@@ -18,17 +18,28 @@ pub fn build(b: *std.Build) void {
         docs.dependOn(&build_docs.step);
     }
 
-    // Reusable modules
-    const pgzx = blk: {
-        const module = b.addModule("pgzx", .{
-            .root_source_file = b.path("./src/pgzx.zig"),
+    // pgzx_pgsys module: C bindings to Postgres
+    const pgzx_pgsys = blk: {
+        const module = b.addModule("pgzx_pgsys", .{
+            .root_source_file = b.path("./src/pgzx/c.zig"),
             .target = target,
             .optimize = optimize,
         });
+
+        // Internal C headers
         module.addIncludePath(b.path("./src/pgzx/c/include/"));
+
+        // Postgres Headers
         module.addIncludePath(.{
             .cwd_relative = pgbuild.getIncludeServerDir(),
         });
+        module.addIncludePath(.{
+            .cwd_relative = pgbuild.getIncludeDir(),
+        });
+        module.addLibraryPath(.{
+            .cwd_relative = pgbuild.getLibDir(),
+        });
+
         // libpq support
         module.addCSourceFiles(.{
             .files = &[_][]const u8{
@@ -39,13 +50,20 @@ pub fn build(b: *std.Build) void {
                 "-I", pgbuild.getIncludeServerDir(),
             },
         });
-        module.addIncludePath(.{
-            .cwd_relative = pgbuild.getIncludeDir(),
-        });
-        module.addLibraryPath(.{
-            .cwd_relative = pgbuild.getLibDir(),
-        });
         module.linkSystemLibrary("pq", .{});
+
+        break :blk module;
+    };
+
+    // pgzx: main project module.
+    // This module re-exports pgzx_pgsys, other generated modules, and utility functions.
+    const pgzx = blk: {
+        const module = b.addModule("pgzx", .{
+            .root_source_file = b.path("./src/pgzx.zig"),
+            .target = target,
+            .optimize = optimize,
+        });
+        module.addImport("pgzx_pgsys", pgzx_pgsys);
 
         break :blk module;
     };

--- a/src/pgzx.zig
+++ b/src/pgzx.zig
@@ -6,7 +6,7 @@
 const std = @import("std");
 
 // Export common set of postgres headers.
-pub const c = @import("pgzx/c.zig");
+pub const c = @import("pgzx_pgsys");
 
 // Utility functions for working with the PostgreSQL C API.
 pub const bgworker = @import("pgzx/bgworker.zig");

--- a/src/pgzx/collections/list.zig
+++ b/src/pgzx/collections/list.zig
@@ -1,4 +1,4 @@
-const c = @import("../c.zig");
+const pg = @import("pgzx_pgsys");
 
 // Wrapper for postgres lists.
 //
@@ -12,15 +12,15 @@ pub fn PointerListOf(comptime T: type) type {
         const Iterator = IteratorOf(T);
         const ReverseIterator = ReverseIteratorOf(T);
 
-        list: ?*c.List,
+        list: ?*pg.List,
 
         pub fn init() Self {
             return Self.initFrom(null);
         }
 
-        pub fn initFrom(from: ?*c.List) Self {
+        pub fn initFrom(from: ?*pg.List) Self {
             if (from) |l| {
-                if (l.type != c.T_List) {
+                if (l.type != pg.T_List) {
                     @panic("Expected a pointer list");
                 }
             }
@@ -28,23 +28,23 @@ pub fn PointerListOf(comptime T: type) type {
         }
 
         pub fn init1(v: *T) Self {
-            return Self.initFrom(c.list_make1_impl(
-                c.T_List,
+            return Self.initFrom(pg.list_make1_impl(
+                pg.T_List,
                 .{ .ptr_value = v },
             ));
         }
 
         pub fn init2(v1: *T, v2: *T) Self {
-            return Self.initFrom(c.list_make2_impl(
-                c.T_List,
+            return Self.initFrom(pg.list_make2_impl(
+                pg.T_List,
                 .{ .ptr_value = v1 },
                 .{ .ptr_value = v2 },
             ));
         }
 
         pub fn init3(v1: *T, v2: *T, v3: *T) Self {
-            return Self.initFrom(c.list_make3_impl(
-                c.T_List,
+            return Self.initFrom(pg.list_make3_impl(
+                pg.T_List,
                 .{ .ptr_value = v1 },
                 .{ .ptr_value = v2 },
                 .{ .ptr_value = v3 },
@@ -52,8 +52,8 @@ pub fn PointerListOf(comptime T: type) type {
         }
 
         pub fn init4(v1: *T, v2: *T, v3: *T, v4: *T) Self {
-            return Self.initFrom(c.list_make4_impl(
-                c.T_List,
+            return Self.initFrom(pg.list_make4_impl(
+                pg.T_List,
                 .{ .ptr_value = v1 },
                 .{ .ptr_value = v2 },
                 .{ .ptr_value = v3 },
@@ -62,8 +62,8 @@ pub fn PointerListOf(comptime T: type) type {
         }
 
         pub fn init5(v1: *T, v2: *T, v3: *T, v4: *T, v5: *T) Self {
-            return Self.initFrom(c.list_make5_impl(
-                c.T_List,
+            return Self.initFrom(pg.list_make5_impl(
+                pg.T_List,
                 .{ .ptr_value = v1 },
                 .{ .ptr_value = v2 },
                 .{ .ptr_value = v3 },
@@ -73,156 +73,156 @@ pub fn PointerListOf(comptime T: type) type {
         }
 
         pub fn deinit(self: Self) void {
-            c.list_free(self.list);
+            pg.list_free(self.list);
         }
 
         pub fn deinitDeep(self: Self) void {
-            c.list_free_deep(self.list);
+            pg.list_free_deep(self.list);
         }
 
-        pub fn rawList(self: Self) ?*c.List {
+        pub fn rawList(self: Self) ?*pg.List {
             return self.list;
         }
 
         pub fn copy(self: Self) Self {
-            return Self.initFrom(c.list_copy(self.list));
+            return Self.initFrom(pg.list_copy(self.list));
         }
 
         pub fn copyDeep(self: Self) Self {
-            return Self.initFrom(c.list_copy_deep(self.list));
+            return Self.initFrom(pg.list_copy_deep(self.list));
         }
 
         pub fn sort(self: Self, cmp: fn (?*T, ?*T) c_int) void {
-            c.list_sort(self.list, struct {
-                fn c_cmp(a: [*c]c.ListCell, b: [*c]c.ListCell) c_int {
-                    const ptrA: ?*T = @ptrCast(@alignCast(c.lfirst(a)));
-                    const ptrB: ?*T = @ptrCast(@alignCast(c.lfirst(b)));
+            pg.list_sort(self.list, struct {
+                fn c_cmp(a: [*c]pg.ListCell, b: [*c]pg.ListCell) c_int {
+                    const ptrA: ?*T = @ptrCast(@alignCast(pg.lfirst(a)));
+                    const ptrB: ?*T = @ptrCast(@alignCast(pg.lfirst(b)));
                     return cmp(ptrA, ptrB);
                 }
             }.c_cmp);
         }
 
         pub fn len(self: Self) usize {
-            return c.list_length(self.list);
+            return pg.list_length(self.list);
         }
 
         pub fn iterator(self: Self) Iterator {
             return Iterator.init(self.list);
         }
 
-        pub fn iteratorFrom(from: ?*c.List) Iterator {
+        pub fn iteratorFrom(from: ?*pg.List) Iterator {
             return Self.initFrom(from).iterator();
         }
 
         pub fn append(self: *Self, value: *T) void {
-            var list: ?*c.List = self.list;
-            list = c.lappend(list, value);
+            var list: ?*pg.List = self.list;
+            list = pg.lappend(list, value);
             self.list = list;
         }
 
         pub fn concatUnique(self: *Self, other: Self) void {
-            self.list = c.list_concat_unique(self.list, other.list);
+            self.list = pg.list_concat_unique(self.list, other.list);
         }
 
         pub fn concatUniquePtr(self: *Self, other: Self) void {
-            self.list = c.list_concat_unique_ptr(self.list, other.list);
+            self.list = pg.list_concat_unique_ptr(self.list, other.list);
         }
 
         pub fn reverseIterator(self: Self) ReverseIterator {
             return ReverseIterator.init(self.list);
         }
 
-        pub fn reverseIteratorFrom(from: ?*c.List) ReverseIterator {
+        pub fn reverseIteratorFrom(from: ?*pg.List) ReverseIterator {
             return Self.initFrom(from).reverseIterator();
         }
 
         pub fn member(self: Self, value: *T) bool {
-            return c.list_member(self.list, value);
+            return pg.list_member(self.list, value);
         }
 
         pub fn memberPtr(self: Self, value: *T) bool {
-            return c.list_member_ptr(self.list, value);
+            return pg.list_member_ptr(self.list, value);
         }
 
         pub fn deleteNth(self: *Self, n: usize) void {
             if (n >= self.len()) {
                 @panic("Index out of bounds");
             }
-            self.list = c.list_delete_nth(self.list, @intCast(n));
+            self.list = pg.list_delete_nth(self.list, @intCast(n));
         }
 
         pub fn deleteFirst(self: *Self) void {
-            self.list = c.list_delete_first(self.list);
+            self.list = pg.list_delete_first(self.list);
         }
 
         pub fn deleteFirstN(self: *Self, n: usize) void {
-            self.list = c.list_delete_first_n(self.list, @intCast(n));
+            self.list = pg.list_delete_first_n(self.list, @intCast(n));
         }
 
         pub fn deleteLast(self: *Self) void {
-            self.list = c.list_delete_last(self.list);
+            self.list = pg.list_delete_last(self.list);
         }
 
         pub fn delete(self: *Self, value: *T) void {
-            self.list = c.list_delete(self.list, value);
+            self.list = pg.list_delete(self.list, value);
         }
 
         pub fn deletePointer(self: *Self, value: *T) void {
-            self.list = c.list_delete_ptr(self.list, value);
+            self.list = pg.list_delete_ptr(self.list, value);
         }
 
         pub fn createUnion(self: Self, other: *Self) Self {
-            return Self.initFrom(c.list_union(self.list, other.list));
+            return Self.initFrom(pg.list_union(self.list, other.list));
         }
 
         pub fn createUnionPtr(self: Self, other: Self) Self {
-            return Self.initFrom(c.list_union_ptr(self.list, other.list));
+            return Self.initFrom(pg.list_union_ptr(self.list, other.list));
         }
 
         pub fn createIntersection(self: Self, other: Self) Self {
-            return Self.initFrom(c.list_intersection(self.list, other.list));
+            return Self.initFrom(pg.list_intersection(self.list, other.list));
         }
 
         pub fn createIntersectionPtr(self: Self, other: Self) Self {
-            return Self.initFrom(c.list_intersection_ptr(self.list, other.list));
+            return Self.initFrom(pg.list_intersection_ptr(self.list, other.list));
         }
 
         pub fn createDifference(self: Self, other: Self) Self {
-            return Self.initFrom(c.list_difference(self.list, other.list));
+            return Self.initFrom(pg.list_difference(self.list, other.list));
         }
 
         pub fn createDifferencePtr(self: Self, other: Self) Self {
-            return Self.initFrom(c.list_difference_ptr(self.list, other.list));
+            return Self.initFrom(pg.list_difference_ptr(self.list, other.list));
         }
     };
 }
 
 pub fn IteratorOf(comptime T: type) type {
-    return IteratorOfWith(T, c.list_head, c.lnext);
+    return IteratorOfWith(T, pg.list_head, pg.lnext);
 }
 
 pub fn ReverseIteratorOf(comptime T: type) type {
-    return IteratorOfWith(T, c.list_last_cell, lprev);
+    return IteratorOfWith(T, pg.list_last_cell, lprev);
 }
 
-fn lprev(list: *c.List, cell: *c.ListCell) ?*c.ListCell {
-    const idx = c.list_cell_number(list, cell);
+fn lprev(list: *pg.List, cell: *pg.ListCell) ?*pg.ListCell {
+    const idx = pg.list_cell_number(list, cell);
     if (idx <= 0) {
         return null;
     }
-    return c.list_nth_cell(list, idx - 1);
+    return pg.list_nth_cell(list, idx - 1);
 }
 
 fn IteratorOfWith(comptime T: type, comptime fn_init: anytype, comptime fn_next: anytype) type {
     return struct {
-        list: *c.List,
-        cell: ?*c.ListCell,
+        list: *pg.List,
+        cell: ?*pg.ListCell,
 
         const Self = @This();
 
-        pub fn init(list: ?*c.List) Self {
+        pub fn init(list: ?*pg.List) Self {
             if (list) |l| {
-                if (l.type != c.T_List) {
+                if (l.type != pg.T_List) {
                     @panic("Expected a pointer list");
                 }
                 return Self{ .list = l, .cell = fn_init(l) };
@@ -235,7 +235,7 @@ fn IteratorOfWith(comptime T: type, comptime fn_init: anytype, comptime fn_next:
         pub fn next(self: *Self) ??*T {
             if (self.cell) |cell| {
                 self.cell = fn_next(self.list, cell);
-                const value: ?*T = @ptrCast(@alignCast(c.lfirst(cell)));
+                const value: ?*T = @ptrCast(@alignCast(pg.lfirst(cell)));
                 return value;
             }
             return null;

--- a/src/pgzx/collections/slist.zig
+++ b/src/pgzx/collections/slist.zig
@@ -2,9 +2,9 @@
 
 const std = @import("std");
 
-const c = @import("../c.zig");
+const pg = @import("pgzx_pgsys");
 
-fn initNode() c.slist_node {
+fn initNode() pg.slist_node {
     return .{ .next = null };
 }
 
@@ -15,15 +15,15 @@ pub fn SList(comptime T: type, comptime node_field: std.meta.FieldEnum(T)) type 
 
         usingnamespace SListMeta(T, node_field);
 
-        head: c.slist_head,
+        head: pg.slist_head,
 
         pub inline fn init() Self {
             var h = Self{ .head = undefined };
-            c.slist_init(&h.head);
+            pg.slist_init(&h.head);
             return h;
         }
 
-        pub inline fn initWith(init_head: c.slist_head) Self {
+        pub inline fn initWith(init_head: pg.slist_head) Self {
             return Self{ .head = init_head };
         }
 
@@ -34,20 +34,20 @@ pub fn SList(comptime T: type, comptime node_field: std.meta.FieldEnum(T)) type 
         }
 
         pub inline fn isEmpty(self: Self) bool {
-            return c.slist_is_empty(&self.head);
+            return pg.slist_is_empty(&self.head);
         }
 
         pub inline fn pushHead(self: *Self, v: *T) void {
-            c.slist_push_head(&self.head, Self.nodePtr(v));
+            pg.slist_push_head(&self.head, Self.nodePtr(v));
         }
 
         pub inline fn popHead(self: *Self) ?*T {
-            const node_ptr = c.slist_pop_head_node(&self.head);
+            const node_ptr = pg.slist_pop_head_node(&self.head);
             return Self.optNodeParentPtr(node_ptr);
         }
 
         pub inline fn headNode(self: Self) ?*T {
-            const node_ptr = c.slist_head_node(@constCast(&self.head));
+            const node_ptr = pg.slist_head_node(@constCast(&self.head));
             return Self.optNodeParentPtr(node_ptr);
         }
 
@@ -57,13 +57,13 @@ pub fn SList(comptime T: type, comptime node_field: std.meta.FieldEnum(T)) type 
             const next_ptr = self.head.head.next.*.next;
             if (next_ptr == null) return null;
 
-            var new_head: c.slist_head = undefined;
+            var new_head: pg.slist_head = undefined;
             new_head.head.next = next_ptr;
             return Self.initWith(new_head);
         }
 
         pub inline fn insertAfter(prev: *T, v: *T) void {
-            c.slist_insert_after(Self.nodePtr(prev), Self.nodePtr(v));
+            pg.slist_insert_after(Self.nodePtr(prev), Self.nodePtr(v));
         }
 
         pub inline fn hasNext(v: *T) bool {
@@ -71,12 +71,12 @@ pub fn SList(comptime T: type, comptime node_field: std.meta.FieldEnum(T)) type 
         }
 
         pub inline fn next(v: *T) ?*T {
-            const node_ptr = c.slist_next(Self.nodePtr(v));
+            const node_ptr = pg.slist_next(Self.nodePtr(v));
             return Self.optNodeParentPtr(node_ptr);
         }
 
         pub inline fn iterator(self: *Self) Iterator {
-            var i: c.slist_iter = undefined;
+            var i: pg.slist_iter = undefined;
             i.cur = self.head.head.next;
             return .{ .iter = i };
         }
@@ -88,7 +88,7 @@ pub fn SListIter(comptime T: type, comptime node_field: std.meta.FieldEnum(T)) t
         const Self = @This();
         usingnamespace SListMeta(T, node_field);
 
-        iter: c.slist_iter,
+        iter: pg.slist_iter,
 
         pub inline fn next(self: *Self) ?*T {
             if (self.iter.cur == null) return null;
@@ -103,15 +103,15 @@ fn SListMeta(comptime T: type, comptime node_field: std.meta.FieldEnum(T)) type 
     return struct {
         const node = std.meta.fieldInfo(T, node_field).name;
 
-        inline fn nodePtr(v: *T) *c.slist_node {
+        inline fn nodePtr(v: *T) *pg.slist_node {
             return &@field(v, node);
         }
 
-        inline fn nodeParentPtr(n: *c.slist_node) ?*T {
+        inline fn nodeParentPtr(n: *pg.slist_node) ?*T {
             return @fieldParentPtr(node, n);
         }
 
-        inline fn optNodeParentPtr(n: ?*c.slist_node) ?*T {
+        inline fn optNodeParentPtr(n: ?*pg.slist_node) ?*T {
             return if (n) |p| nodeParentPtr(p) else null;
         }
     };
@@ -121,7 +121,7 @@ pub const TestSuite_SList = struct {
     pub fn testEmpty() !void {
         const T = struct {
             value: u32,
-            node: c.slist_node,
+            node: pg.slist_node,
         };
         const MyList = SList(T, .node);
 
@@ -138,7 +138,7 @@ pub const TestSuite_SList = struct {
     pub fn testPush() !void {
         const T = struct {
             value: u32,
-            node: c.slist_node = .{ .next = null },
+            node: pg.slist_node = .{ .next = null },
         };
         const MyListT = SList(T, .node);
 
@@ -165,7 +165,7 @@ pub const TestSuite_SList = struct {
     pub fn testPop() !void {
         const T = struct {
             value: u32,
-            node: c.slist_node = .{ .next = null },
+            node: pg.slist_node = .{ .next = null },
         };
         const MyListT = SList(T, .node);
 

--- a/src/pgzx/fdw.zig
+++ b/src/pgzx/fdw.zig
@@ -1,9 +1,10 @@
 const std = @import("std");
 
+const pg = @import("pgzx_pgsys");
+
 const elog = @import("elog.zig");
 const mem = @import("mem.zig");
 const collections = @import("collections.zig");
-const pg = @import("c.zig");
 
 pub const DefElem = pg.DefElem;
 

--- a/src/pgzx/fmgr.zig
+++ b/src/pgzx/fmgr.zig
@@ -1,15 +1,16 @@
 const std = @import("std");
 
-const c = @import("c.zig");
+const pg = @import("pgzx_pgsys");
+
 const elog = @import("elog.zig");
 const datum = @import("datum.zig");
 const meta = @import("meta.zig");
 
 pub const args = @import("fmgr/args.zig");
-pub const varatt = c.varatt;
+pub const varatt = pg.varatt;
 
-pub const Pg_magic_struct = c.Pg_magic_struct;
-pub const Pg_finfo_record = c.Pg_finfo_record;
+pub const Pg_magic_struct = pg.Pg_magic_struct;
+pub const Pg_finfo_record = pg.Pg_finfo_record;
 
 pub const MAGIC = [*c]const Pg_magic_struct;
 pub const FN_INFO_V1 = [*c]const Pg_finfo_record;
@@ -18,11 +19,11 @@ pub const FN_INFO_V1 = [*c]const Pg_finfo_record;
 /// This value must be returned by a function named `Pg_magic_func`.
 pub const PG_MAGIC = Pg_magic_struct{
     .len = @bitCast(@as(c_uint, @truncate(@sizeOf(Pg_magic_struct)))),
-    .version = @divTrunc(c.PG_VERSION_NUM, @as(c_int, 100)),
-    .funcmaxargs = c.FUNC_MAX_ARGS,
-    .indexmaxkeys = c.INDEX_MAX_KEYS,
-    .namedatalen = c.NAMEDATALEN,
-    .float8byval = c.FLOAT8PASSBYVAL,
+    .version = @divTrunc(pg.PG_VERSION_NUM, @as(c_int, 100)),
+    .funcmaxargs = pg.FUNC_MAX_ARGS,
+    .indexmaxkeys = pg.INDEX_MAX_KEYS,
+    .namedatalen = pg.NAMEDATALEN,
+    .float8byval = pg.FLOAT8PASSBYVAL,
     .abi_extra = [32]u8{ 'P', 'o', 's', 't', 'g', 'r', 'e', 'S', 'Q', 'L', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
 };
 
@@ -67,7 +68,7 @@ pub inline fn PG_FUNCTION_V1(comptime name: []const u8, comptime callback: anyty
 inline fn genFnCall(comptime f: anytype) type {
     return struct {
         const function: @TypeOf(f) = f;
-        fn call(fcinfo: c.FunctionCallInfo) callconv(.C) c.Datum {
+        fn call(fcinfo: pg.FunctionCallInfo) callconv(.C) pg.Datum {
             return pgCall(@src(), function, fcinfo);
         }
     };
@@ -79,8 +80,8 @@ pub const ArgType = args.ArgType;
 pub inline fn pgCall(
     comptime src: std.builtin.SourceLocation,
     comptime impl: anytype,
-    fcinfo: c.FunctionCallInfo,
-) c.Datum {
+    fcinfo: pg.FunctionCallInfo,
+) pg.Datum {
     const fnType = @TypeOf(impl);
     const funcArgType = std.meta.ArgsTuple(fnType);
 

--- a/src/pgzx/interrupts.zig
+++ b/src/pgzx/interrupts.zig
@@ -1,9 +1,10 @@
-const c = @import("c.zig");
+const pg = @import("pgzx_pgsys");
+
 const err = @import("err.zig");
 
 /// Use Signal to create volatile variables that you can set in signal
 /// handlers.
-pub const Signal = Volatile(c.sig_atomic_t);
+pub const Signal = Volatile(pg.sig_atomic_t);
 
 /// Use SignalOf to create volatile variables based on existing C based
 /// `volatile sig_atomic_t` variables.
@@ -12,7 +13,7 @@ pub const Signal = Volatile(c.sig_atomic_t);
 /// The zig translator does not translate support the C `volatile` keyword,
 /// because you can only mark pointers as volatile. For this reason we MUST
 /// wrap C based `volatile sig_atomic_t` variables.
-pub const SignalOf = VolatilePtr(c.sig_atomic_t);
+pub const SignalOf = VolatilePtr(pg.sig_atomic_t);
 
 pub fn VolatilePtr(comptime T: type) type {
     return struct {
@@ -82,25 +83,25 @@ pub fn Volatile(comptime T: type) type {
 
 pub const Pending = struct {
     // signals
-    pub const Interrupt = SignalOf.create(&c.InterruptPending);
-    pub const QueryCancel = SignalOf.create(&c.QueryCancelPending);
-    pub const ProcDie = SignalOf.create(&c.ProcDiePending);
-    pub const CheckClientConnection = SignalOf.create(&c.CheckClientConnectionPending);
-    pub const ClientConnectionLost = SignalOf.create(&c.ClientConnectionLost);
-    pub const IdleInTransactionSessionTimeout = SignalOf.create(&c.IdleInTransactionSessionTimeoutPending);
-    pub const IdleSessionTimeout = SignalOf.create(&c.IdleSessionTimeoutPending);
-    pub const ProcSignalBarrier = SignalOf.create(&c.ProcSignalBarrierPending);
-    pub const LogMemoryContext = SignalOf.create(&c.LogMemoryContextPending);
-    pub const IdleStatsUpdateTimeout = SignalOf.create(&c.IdleStatsUpdateTimeoutPending);
+    pub const Interrupt = SignalOf.create(&pg.InterruptPending);
+    pub const QueryCancel = SignalOf.create(&pg.QueryCancelPending);
+    pub const ProcDie = SignalOf.create(&pg.ProcDiePending);
+    pub const CheckClientConnection = SignalOf.create(&pg.CheckClientConnectionPending);
+    pub const ClientConnectionLost = SignalOf.create(&pg.ClientConnectionLost);
+    pub const IdleInTransactionSessionTimeout = SignalOf.create(&pg.IdleInTransactionSessionTimeoutPending);
+    pub const IdleSessionTimeout = SignalOf.create(&pg.IdleSessionTimeoutPending);
+    pub const ProcSignalBarrier = SignalOf.create(&pg.ProcSignalBarrierPending);
+    pub const LogMemoryContext = SignalOf.create(&pg.LogMemoryContextPending);
+    pub const IdleStatsUpdateTimeout = SignalOf.create(&pg.IdleStatsUpdateTimeoutPending);
 
     // counts:
-    pub const InterruptHoldoffCount = VolatilePtr(u32).create(&c.InterruptHoldoffCount);
-    pub const QueryCancelHoldoffCount = VolatilePtr(u32).create(&c.QueryCancelHoldoffCount);
-    pub const CritSectionCount = VolatilePtr(u32).create(&c.CritSectionCount);
+    pub const InterruptHoldoffCount = VolatilePtr(u32).create(&pg.InterruptHoldoffCount);
+    pub const QueryCancelHoldoffCount = VolatilePtr(u32).create(&pg.QueryCancelHoldoffCount);
+    pub const CritSectionCount = VolatilePtr(u32).create(&pg.CritSectionCount);
 };
 
 pub inline fn CheckForInterrupts() !void {
     if (Pending.Interrupt.read() != 0) {
-        try err.wrap(c.ProcessInterrupts, .{});
+        try err.wrap(pg.ProcessInterrupts, .{});
     }
 }

--- a/src/pgzx/lwlock.zig
+++ b/src/pgzx/lwlock.zig
@@ -4,16 +4,16 @@
 //! The global locks like `AddinShmemInitLock` are not directly accessible from
 //! the generated C bindings. We provide wrapper functions for them here.
 
-const c = @import("c.zig");
+const pg = @import("pgzx_pgsys");
 
 // access `MainLWLockArray`.
 //
 // We use a function because the Zig compiler currently complains that it can
 // access the ID only at runtime.
-inline fn mainLock(id: usize) fn () *c.LWLock {
+inline fn mainLock(id: usize) fn () *pg.LWLock {
     return struct {
-        fn call() *c.LWLock {
-            return &c.MainLWLockArray[id].lock;
+        fn call() *pg.LWLock {
+            return &pg.MainLWLockArray[id].lock;
         }
     }.call;
 }

--- a/src/pgzx/pq/conv.zig
+++ b/src/pgzx/pq/conv.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-const c = @import("../c.zig");
+const pg = @import("pgzx_pgsys");
 const meta = @import("../meta.zig");
 
 pub const Error = error{
@@ -88,7 +88,7 @@ fn optconv(comptime C: type) type {
 }
 
 const boolconv = struct {
-    pub const OID = c.BOOLOID;
+    pub const OID = pg.BOOLOID;
     pub const Type = bool;
 
     pub fn write(writer: anytype, value: bool) !void {
@@ -112,14 +112,14 @@ const boolconv = struct {
     }
 };
 
-const i8conv = intconv(i8, c.INT2OID);
-const i16conv = intconv(i16, c.INT2OID);
-const i32conv = intconv(i32, c.INT4OID);
-const i64conv = intconv(i64, c.INT8OID);
-const u8conv = intconv(u8, c.INT2OID);
-const u16conv = intconv(u16, c.INT4OID);
-const u32conv = intconv(u32, c.INT8OID);
-fn intconv(comptime T: type, comptime oid: c.Oid) type {
+const i8conv = intconv(i8, pg.INT2OID);
+const i16conv = intconv(i16, pg.INT2OID);
+const i32conv = intconv(i32, pg.INT4OID);
+const i64conv = intconv(i64, pg.INT8OID);
+const u8conv = intconv(u8, pg.INT2OID);
+const u16conv = intconv(u16, pg.INT4OID);
+const u32conv = intconv(u32, pg.INT8OID);
+fn intconv(comptime T: type, comptime oid: pg.Oid) type {
     return struct {
         pub const OID = oid;
         pub const Type = T;
@@ -137,9 +137,9 @@ fn intconv(comptime T: type, comptime oid: c.Oid) type {
     };
 }
 
-const f32conv = floatconv(f32, c.FLOAT4OID);
-const f64conv = floatconv(f64, c.FLOAT8OID);
-fn floatconv(comptime T: type, comptime oid: c.Oid) type {
+const f32conv = floatconv(f32, pg.FLOAT4OID);
+const f64conv = floatconv(f64, pg.FLOAT8OID);
+fn floatconv(comptime T: type, comptime oid: pg.Oid) type {
     return struct {
         pub const OID = oid;
         pub const Type = T;
@@ -158,7 +158,7 @@ fn floatconv(comptime T: type, comptime oid: c.Oid) type {
 }
 
 const textconv = struct {
-    pub const OID = c.TEXTOID;
+    pub const OID = pg.TEXTOID;
     pub const Type = []const u8;
 
     pub fn write(writer: anytype, value: []const u8) !void {
@@ -172,7 +172,7 @@ const textconv = struct {
 };
 
 const textzconv = struct {
-    pub const OID = c.TEXTOID;
+    pub const OID = pg.TEXTOID;
     pub const Type = [:0]const u8;
 
     pub fn write(writer: anytype, value: [:0]const u8) !void {

--- a/src/pgzx/pq/params.zig
+++ b/src/pgzx/pq/params.zig
@@ -1,6 +1,6 @@
 // const std = @import("std");
 // const conv = @import("conv.zig");
-// const c = @import("../c.zig");
+// const c = @import("pgzx_pgsys");
 //
 // pub fn buildParams(allocator: std.mem.Allocator, params: anytype) !Params {
 //     return Builder.new(allocator).build(params);

--- a/src/pgzx/shmem.zig
+++ b/src/pgzx/shmem.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-const c = @import("c.zig");
+const pg = @import("pgzx_pgsys");
 
 pub inline fn registerHooks(comptime T: anytype) void {
     if (std.meta.hasFn(T, "requestHook")) {
@@ -23,7 +23,7 @@ pub inline fn registerSharedState(comptime T: type, shared_state: **T) void {
 
         pub fn startupHook() void {
             var found = false;
-            const ptr = c.ShmemInitStruct(T.SHMEM_NAME, @sizeOf(T), &found);
+            const ptr = pg.ShmemInitStruct(T.SHMEM_NAME, @sizeOf(T), &found);
             shared_state.* = @ptrCast(@alignCast(ptr));
             if (!found) {
                 if (std.meta.hasFn(T, "init")) {
@@ -37,11 +37,11 @@ pub inline fn registerSharedState(comptime T: type, shared_state: **T) void {
 }
 
 pub inline fn registerRequestHook(f: anytype) void {
-    registerHook(f, &c.shmem_request_hook);
+    registerHook(f, &pg.shmem_request_hook);
 }
 
 pub inline fn registerStartupHook(f: anytype) void {
-    registerHook(f, &c.shmem_startup_hook);
+    registerHook(f, &pg.shmem_startup_hook);
 }
 
 inline fn registerHook(f: anytype, hook: anytype) void {
@@ -60,12 +60,12 @@ inline fn registerHook(f: anytype, hook: anytype) void {
 }
 
 pub inline fn requestSpaceFor(comptime T: type) void {
-    c.RequestAddinShmemSpace(@sizeOf(T));
+    pg.RequestAddinShmemSpace(@sizeOf(T));
 }
 
 pub inline fn createAndZero(comptime T: type) *T {
     var found = false;
-    const ptr = c.ShmemInitStruct(T.SHMEM_NAME, @sizeOf(T), &found);
+    const ptr = pg.ShmemInitStruct(T.SHMEM_NAME, @sizeOf(T), &found);
     const shared_state: *T = @ptrCast(@alignCast(ptr));
     if (!found) {
         shared_state.* = std.mem.zeroes(T);
@@ -77,7 +77,7 @@ pub inline fn createAndInit(comptime T: type) *T {
     // TODO: check that T implements init
 
     var found = false;
-    const ptr = c.ShmemInitStruct(T.SHMEM_NAME, @sizeOf(T), &found);
+    const ptr = pg.ShmemInitStruct(T.SHMEM_NAME, @sizeOf(T), &found);
     const shared_state: *T = @ptrCast(@alignCast(ptr));
     if (!found) {
         shared_state.init();

--- a/src/pgzx/testing.zig
+++ b/src/pgzx/testing.zig
@@ -1,10 +1,11 @@
 const std = @import("std");
 
+pub const pg = @import("pgzx_pgsys");
+
 pub const err = @import("err.zig");
 pub const elog = @import("elog.zig");
 pub const fmgr = @import("fmgr.zig");
 pub const mem = @import("mem.zig");
-pub const pg = @import("c.zig");
 pub const pgzx_err = @import("err.zig");
 
 /// This function registers a set of test suites to be run inside the Postgres server. A `run_tests` function is

--- a/src/pgzx/utils/guc.zig
+++ b/src/pgzx/utils/guc.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-const c = @import("../c.zig");
+const pg = @import("pgzx_pgsys");
 
 pub const CustomBoolVariable = struct {
     value: bool,
@@ -10,11 +10,11 @@ pub const CustomBoolVariable = struct {
         short_desc: ?[:0]const u8 = null,
         long_desc: ?[:0]const u8 = null,
         initial_value: bool = false,
-        context: c.GucContext = c.PGC_USERSET,
+        context: pg.GucContext = pg.PGC_USERSET,
         flags: c_int = 0,
-        check_hook: c.GucBoolCheckHook = null,
-        assign_hook: c.GucBoolAssignHook = null,
-        show_hook: c.GucShowHook = null,
+        check_hook: pg.GucBoolCheckHook = null,
+        assign_hook: pg.GucBoolAssignHook = null,
+        show_hook: pg.GucShowHook = null,
     };
 
     pub fn registerValue(options: Options) void {
@@ -27,7 +27,7 @@ pub const CustomBoolVariable = struct {
     }
 
     fn doRegister(value: ?*bool, options: Options) void {
-        c.DefineCustomBoolVariable(
+        pg.DefineCustomBoolVariable(
             options.name,
             optSliceCPtr(options.short_desc),
             optSliceCPtr(options.long_desc),
@@ -52,11 +52,11 @@ pub const CustomIntVariable = struct {
         initial_value: ?c_int = 0,
         min_value: c_int = 0,
         max_value: c_int = std.math.maxInt(c_int),
-        context: c.GucContext = c.PGC_USERSET,
+        context: pg.GucContext = pg.PGC_USERSET,
         flags: c_int = 0,
-        check_hook: c.GucIntCheckHook = null,
-        assign_hook: c.GucIntAssignHook = null,
-        show_hook: c.GucShowHook = null,
+        check_hook: pg.GucIntCheckHook = null,
+        assign_hook: pg.GucIntAssignHook = null,
+        show_hook: pg.GucShowHook = null,
     };
 
     pub fn registerValue(options: Options) void {
@@ -72,7 +72,7 @@ pub const CustomIntVariable = struct {
 
     fn doRegister(value: ?*c_int, options: Options) void {
         const init_value = if (value) |v| v.* else options.initial_value orelse 0;
-        c.DefineCustomIntVariable(
+        pg.DefineCustomIntVariable(
             options.name,
             optSliceCPtr(options.short_desc),
             optSliceCPtr(options.long_desc),
@@ -97,7 +97,7 @@ pub const CustomStringVariable = struct {
         short_desc: ?[:0]const u8 = null,
         long_desc: ?[:0]const u8 = null,
         initial_value: ?[:0]const u8 = null,
-        context: c.GucContext = c.PGC_USERSET,
+        context: pg.GucContext = pg.PGC_USERSET,
         flags: c_int = 0,
     };
 
@@ -108,7 +108,7 @@ pub const CustomStringVariable = struct {
             self._value = v.ptr;
         }
 
-        c.DefineCustomStringVariable(
+        pg.DefineCustomStringVariable(
             options.name,
             optSliceCPtr(options.short_desc),
             optSliceCPtr(options.long_desc),
@@ -144,15 +144,15 @@ pub const CustomIntOptions = struct {
     boot_value: c_int = 0,
     min_value: c_int = 0,
     max_value: c_int = std.math.maxInt(c_int),
-    context: c.GucContext = c.PGC_USERSET,
+    context: pg.GucContext = pg.PGC_USERSET,
     flags: c_int = 0,
-    check_hook: c.GucIntCheckHook = null,
-    assign_hook: c.GucIntAssignHook = null,
-    show_hook: c.GucShowHook = null,
+    check_hook: pg.GucIntCheckHook = null,
+    assign_hook: pg.GucIntAssignHook = null,
+    show_hook: pg.GucShowHook = null,
 };
 
 pub fn defineCustomInt(options: CustomIntOptions) void {
-    c.DefineCustomIntVariable(
+    pg.DefineCustomIntVariable(
         options.name,
         optSliceCPtr(options.short_desc),
         optSliceCPtr(options.long_desc),

--- a/src/pgzx/varatt.zig
+++ b/src/pgzx/varatt.zig
@@ -1,7 +1,7 @@
 //! varatt replaces the VA<...> macros from utils/varattr.h that Zig didn't
 //! compile correctly.
 
-const c = @import("c.zig");
+const pg = @import("pgzx_pgsys");
 
 // WARNING:
 // Taken from translated C code and mostly untested.
@@ -11,28 +11,28 @@ const c = @import("c.zig");
 // We do not want to expose these directly, but we must make sure that we test
 // all variable conversions to make sure that code actually compiles.
 
-pub const VARHDRSZ = c.VARHDRSZ;
+pub const VARHDRSZ = pg.VARHDRSZ;
 pub const VARHDRSZ_SHORT = @sizeOf(varattrib_1b);
 pub const VARHDRSZ_EXTERNAL = @sizeOf(varattrib_1b_e);
 
-pub const VARLENA_EXTSIZE_BITS = c.VARLENA_EXTSIZE_BITS;
+pub const VARLENA_EXTSIZE_BITS = pg.VARLENA_EXTSIZE_BITS;
 
-pub const VARTAG_EXPANDED_RO = c.VARTAG_EXPANDED_RO;
-pub const VARTAG_EXPANDED_RW = c.VARTAG_EXPANDED_RW;
-pub const VARTAG_INDIRECT = c.VARTAG_INDIRECT;
-pub const VARTAG_ONDISK = c.VARTAG_ONDISK;
+pub const VARTAG_EXPANDED_RO = pg.VARTAG_EXPANDED_RO;
+pub const VARTAG_EXPANDED_RW = pg.VARTAG_EXPANDED_RW;
+pub const VARTAG_INDIRECT = pg.VARTAG_INDIRECT;
+pub const VARTAG_ONDISK = pg.VARTAG_ONDISK;
 
-pub const SET_VARSIZE_4B = c.SET_VARSIZE_4B;
-pub const SET_VARSIZE_1B = c.SET_VARSIZE_1B;
-pub const SET_VARSIZE_4B_C = c.SET_VARSIZE_4B_C;
-pub const SET_VARTAG_1B_E = c.SET_VARTAG_1B_E;
+pub const SET_VARSIZE_4B = pg.SET_VARSIZE_4B;
+pub const SET_VARSIZE_1B = pg.SET_VARSIZE_1B;
+pub const SET_VARSIZE_4B_C = pg.SET_VARSIZE_4B_C;
+pub const SET_VARTAG_1B_E = pg.SET_VARTAG_1B_E;
 
-pub const varatt_indirect = c.varatt_indirect;
-pub const varatt_expanded = c.varatt_expanded;
-pub const varatt_external = c.varatt_external;
-pub const varattrib_1b = c.varattrib_1b;
-pub const varattrib_4b = c.varattrib_4b;
-pub const varattrib_1b_e = c.varattrib_1b_e;
+pub const varatt_indirect = pg.varatt_indirect;
+pub const varatt_expanded = pg.varatt_expanded;
+pub const varatt_external = pg.varatt_external;
+pub const varattrib_1b = pg.varattrib_1b;
+pub const varattrib_4b = pg.varattrib_4b;
+pub const varattrib_1b_e = pg.varattrib_1b_e;
 
 pub const VARLENA_EXTSIZE_MASK = (@as(c_uint, 1) << VARLENA_EXTSIZE_BITS) - @as(c_int, 1);
 
@@ -71,17 +71,17 @@ pub inline fn VARATT_IS_1B_E(PTR: anytype) @TypeOf(@import("std").zig.c_translat
     return @import("std").zig.c_translation.cast([*c]varattrib_1b, PTR).*.va_header == @as(c_int, 0x01);
 }
 
-pub inline fn VARATT_NOT_PAD_BYTE(PTR: anytype) @TypeOf(@import("std").zig.c_translation.cast([*c]c.uint8, PTR).* != @as(c_int, 0)) {
-    return @import("std").zig.c_translation.cast([*c]c.uint8, PTR).* != @as(c_int, 0);
+pub inline fn VARATT_NOT_PAD_BYTE(PTR: anytype) @TypeOf(@import("std").zig.c_translation.cast([*c]pg.uint8, PTR).* != @as(c_int, 0)) {
+    return @import("std").zig.c_translation.cast([*c]pg.uint8, PTR).* != @as(c_int, 0);
 }
 
-pub inline fn VARSIZE_4B(PTR: anytype) @TypeOf((@import("std").zig.c_translation.cast([*c]varattrib_4b, PTR).*.va_4byte.va_header >> @as(c.uint32, 2)) & @import("std").zig.c_translation.promoteIntLiteral(c.uint32, 0x3FFFFFFF, .hex)) {
+pub inline fn VARSIZE_4B(PTR: anytype) @TypeOf((@import("std").zig.c_translation.cast([*c]varattrib_4b, PTR).*.va_4byte.va_header >> @as(pg.uint32, 2)) & @import("std").zig.c_translation.promoteIntLiteral(pg.uint32, 0x3FFFFFFF, .hex)) {
     _ = &PTR;
-    return (@import("std").zig.c_translation.cast([*c]varattrib_4b, PTR).*.va_4byte.va_header >> @as(c.uint32, 2)) & @import("std").zig.c_translation.promoteIntLiteral(c.uint32, 0x3FFFFFFF, .hex);
+    return (@import("std").zig.c_translation.cast([*c]varattrib_4b, PTR).*.va_4byte.va_header >> @as(pg.uint32, 2)) & @import("std").zig.c_translation.promoteIntLiteral(pg.uint32, 0x3FFFFFFF, .hex);
 }
 
-pub inline fn VARSIZE_1B(PTR: anytype) @TypeOf((@import("std").zig.c_translation.cast([*c]varattrib_1b, PTR).*.va_header >> @as(c.uint32, 1)) & @as(c.uint32, 0x7F)) {
-    return (@import("std").zig.c_translation.cast([*c]varattrib_1b, PTR).*.va_header >> @as(c.uint32, 1)) & @as(c.uint32, 0x7F);
+pub inline fn VARSIZE_1B(PTR: anytype) @TypeOf((@import("std").zig.c_translation.cast([*c]varattrib_1b, PTR).*.va_header >> @as(pg.uint32, 1)) & @as(pg.uint32, 0x7F)) {
+    return (@import("std").zig.c_translation.cast([*c]varattrib_1b, PTR).*.va_header >> @as(pg.uint32, 1)) & @as(pg.uint32, 0x7F);
 }
 
 pub inline fn VARTAG_1B_E(PTR: anytype) @TypeOf(@import("std").zig.c_translation.cast([*c]varattrib_1b_e, PTR).*.va_tag) {

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -1,4 +1,4 @@
-const pgzx = @import("pgzx_pgsys");
+const pgzx = @import("pgzx.zig");
 
 comptime {
     pgzx.PG_MODULE_MAGIC();

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -1,4 +1,4 @@
-const pgzx = @import("pgzx.zig");
+const pgzx = @import("pgzx_pgsys");
 
 comptime {
     pgzx.PG_MODULE_MAGIC();


### PR DESCRIPTION
Requires: #65 

With this change we split the C include and the `pgzx` into 2 modules:
- `pgzx_pgsys`: C includes and some custom C helpers
- `pgzx`: High level Zig utilities and abstractions.

The split is to prepare for code generation support. When generating Zig code on the fly the generated code is imported as a module into `pgzx`, but we also want the generated code to depend on the C includes. By splitting out the C support we can have the generated module import `pgsys` as a module dependency itself.

The change follows the pattern in https://github.com/ziglang/zig/blob/master/test/standalone/dep_triangle/build.zig

We still re-export `pgsys` under `pgzx.c`.

Within `pgzx` we replace `const c = @import(...)` with `const pg = @import("pgzx_pgsys");`. Now Postgres API usage is always prefixed with `pg.*` instead of `c.*`, which is also more consistent on how we use the namespaces ourselves and in the example extensions.

Follow ups (not handled in this PR):
- move C support into separate `pgsys` folder
- rename `pgzx.c` to `pgzx.pg`