### PR TITLE
elog(breaking): more C-like API

### DIFF
--- a/src/pgzx/pq.zig
+++ b/src/pgzx/pq.zig
@@ -723,8 +723,5 @@ fn pqError(src: std.builtin.SourceLocation, conn: ?*pg.PGconn) error{PGErrorStac
         return;
     }
 
-    try elog.Report.init(src, pg.ERROR).raise(.{
-        .message = std.mem.span(rawerr),
-    });
-    unreachable;
+    return elog.Error(src, "{s}", .{std.mem.span(rawerr)});
 }


### PR DESCRIPTION
I found the original builder approach somewhat limiting and inefficient because we used to format strings before attempting to log (even if postgres did drop the log message).

Postgres elog API is somewhat complex, yet composable. When using C, APIs might also allow to report an optional soft error with `errsave` or `ereturn`. This cases didn't fit well with the existing Zig API.

The new implementation follows the C macro API more closely by using the functional options pattern. The reporting functions like `ereport`, `ereportNoJump`, `errsave`, ... do capture the options like `errcode` and `errmsg` in a struct. When reporting we call `errstart` which checks if the message is to be reported or not. Only if `errstart` returns true will we evaluate the options given by `errstart` or `errmsg`. This reduces CPU and memory usage especially for debugging logs.
Finally `errfinish` will emit the log and eventually execute a long jump or return a Zig error.

As the API now resembles the C-API more closely it is also easier to move the Postgres practices to Zig code more easiliy. The documentation in `elog.h` is (mostly?) true for the Zig implementation as well.

## Example usage of new API

Error with long jump:

```
elog.ereport(src, .Error, .{
  elog.errcode(pg.ERRCODE_OUT_OF_MEMORY),
  elog.errmsg("Not enough memory", .{}),
}),
```

Error report emitting a Zig error (we use `try` because some error levels will not return an error, but void).

```
try elog.ereportNoJump(@src(), .Error, .{
  elog.errcode(pg.ERRCODE_S_R_E_PROHIBITED_SQL_STATEMENT_ATTEMPTED),
  elog.errmsg("password or GSSAPI delegated credentials required", .{}),
  elog.errdetail("Non-superusers must delegate GSSAPI credentials or provide a password in the user mapping.", .{}),
});
```

Soft error support (will do a longjump using ERROR level if escontext is no `ErrorSaveContext` node type):

```
elog.errsave(@src(), escontext, .{
  elog.errcode(pg.ERRCODE_UNDEFINED_OBJECT),
  elog.errmsg("cluster \"{s}\" does not exist", .{name}),
});
```