### PR TITLE
fmgr: PG_EXPORT

### DIFF
--- a/src/pgzx.zig
+++ b/src/pgzx.zig
@@ -34,6 +34,7 @@ pub const fmgr = @import("pgzx/fmgr.zig");
 pub const PG_MODULE_MAGIC = fmgr.PG_MODULE_MAGIC;
 pub const PG_FUNCTION_V1 = fmgr.PG_FUNCTION_V1;
 pub const PG_FUNCTION_INFO_V1 = fmgr.PG_FUNCTION_INFO_V1;
+pub const PG_EXPORT = fmgr.PG_EXPORT;
 
 pub const lwlock = @import("pgzx/lwlock.zig");
 pub const mem = @import("pgzx/mem.zig");


### PR DESCRIPTION
I got tired of writing `PG_FUNCTION_V1`. The new `PG_EXPORT` helper looks up all public functions in a struct and automatically calls `PG_FUNCTION_V1` for you.

## Examples

export public functions from a zig file:

```
    pgzx.PG_EXPORT(@import("commands/pgd_onboard_remote_schema.zig"));
```

export public functions with anonymous struct:

```
    pgzx.PG_EXPORT(struct{
      pub fn hello() []const u8 { return "hello world"; }

      pub fn add(a: i32, b: i32) i32 { return a + b; } 
    }
```

Zig module with 'sqlexport' module:

```
comptime {
  pgzx.PG_EXPORT(rpc.sqlexport)
}
```

with `rpc.zig`:

```
pub const sqlexport = struct {
  ...
};

// other module functions exported for reuse
```