### PR TITLE
ci: run scripts per example

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -3,115 +3,75 @@
 #set -x
 set -o pipefail
 
-test_pgzx() {
-	rc=0
-	run_unit_tests ./ || rc=1
-	extension_drop pgzx_unit
-	return $rc
-}
-
-test_char_count_zig() {
-	extension_create char_count_zig
-	trap "extension_drop char_count_zig" INT TERM
-
-	rc=0
-	run_regression_tests ./examples/char_count_zig || rc=1
-	run_unit_tests ./examples/char_count_zig || rc=1
-
-	extension_drop char_count_zig
-	return $rc
-}
-
-test_pgaudit_zig() {
-	run_unit_tests ./examples/pgaudit_zig
-}
-
-test_spi_sql() {
-	local rc=0
-	run_regression_tests ./examples/spi_sql || rc=1
-	return $rc
-}
-
-extension_build() {
-	cwd=$(pwd)
-	cd "$1" || return 1
-	zig build -freference-trace -p "$PG_HOME" || return 1
-	cd "$cwd" || return 1
-}
-
-extension_create() {
-	echo "Create extension $1"
-	psql -U postgres -c "CREATE EXTENSION IF NOT EXISTS $1"
-}
-
-extension_drop() {
-	echo "Drop extension $1"
-	psql -U postgres -c "DROP EXTENSION IF EXISTS $1"
-}
-
-run_regression_tests() {
-	echo "Run regression tests"
-
-	cwd=$(pwd)
-	cd "$1" || return 1
-	zig build pg_regress --verbose || return 1
-	cd "$cwd" || return 1
-}
-
-run_unit_tests() {
-	echo "Run unit tests"
-
-	cwd=$(pwd)
-	cd "$1" || return 1
-	zig build -freference-trace -p "$PG_HOME" unit || return 1
-	cd "$cwd" || return 1
-}
-
-run_test_suites() {
-	for t in "$@"; do
-		echo ""
-		echo "# Run $t"
-		if ! $t; then
-			return 1
-		fi
-	done
-}
+examples=(./examples/*)
 
 fail() {
 	echo "$1" >&2
 	exit 1
 }
 
-main() {
-	echo "Build and install extension"
-	eval "$(pgenv)"
-
-	log_init_size=0
-	if [ -f "$PG_CLUSTER_LOG_FILE" ]; then
-		log_init_size=$(stat -c %s "$PG_CLUSTER_LOG_FILE")
-	fi
-	echo "Server log size: $log_init_size"
-
-	extension_build ./examples/char_count_zig || fail "Failed to build char_count_zig"
-	extension_build ./examples/pgaudit_zig || fail "Failed to build pgaudit_zig"
-	extension_build ./examples/spi_sql || fail "Failed to build spi_sql"
-
-	echo "Start PostgreSQL"
-	pgstart || fail "Failed to start PostgreSQL"
-	trap pgstop TERM INT EXIT
-
-	ok=true
-	run_test_suites test_pgzx test_char_count_zig test_pgaudit_zig test_spi_sql || ok=false
-
-	if ! $ok; then
-		printf "\n\nServer log:"
-
-		log_size=$(stat -c %s "$PG_CLUSTER_LOG_FILE")
-		tail -c $((log_size - log_init_size)) "$PG_CLUSTER_LOG_FILE"
-		fail "Regression tests failed"
-	fi
-
-	echo "Success!"
+build_example() {
+	cwd=$(pwd)
+	cd "$1" || return 1
+	./ci/run.sh build || return 1
+	cd "$cwd" || return 1
 }
 
-main
+run_example() {
+	cwd=$(pwd)
+	cd "$1" || return 1
+	./ci/run.sh || return 1
+	cd "$cwd" || return 1
+}
+
+test_pgzx() {
+	rc=0
+	zig build -freference-trace -p "$PG_HOME" unit || rc=1
+	psql -U postgres -c "DROP EXTENSION IF EXISTS pgzx_unit"
+	return $rc
+}
+
+echo "Build and install extension"
+eval "$(pgenv)"
+
+log_init_size=0
+if [ -f "$PG_CLUSTER_LOG_FILE" ]; then
+	log_init_size=$(stat -c %s "$PG_CLUSTER_LOG_FILE")
+fi
+echo "Server log size: $log_init_size"
+
+# build examples
+echo "${examples[@]}"
+build_jobs=()
+for example in "${examples[@]}"; do
+	echo -e "\n\nBuild example $example"
+	build_example "$example" &
+	build_jobs+=($!)
+done
+for job in "${build_jobs[@]}"; do
+	wait "$job" || fail "Failed to build example"
+done
+
+echo -e "\n\nStart PostgreSQL"
+pgstart || fail "Failed to start PostgreSQL"
+trap pgstop TERM INT EXIT
+
+echo -e "\n\nRun pgzx unit tests:"
+test_pgzx || fail "Failed to run pgzx unit tests"
+
+for example in "${examples[@]}"; do
+	echo -e "\n\nRun example CI script $example"
+	run_example "$example" || fail "Failed to run CI script for $example"
+done
+
+ok=true
+
+if ! $ok; then
+	printf "\n\nServer log:"
+
+	log_size=$(stat -c %s "$PG_CLUSTER_LOG_FILE")
+	tail -c $((log_size - log_init_size)) "$PG_CLUSTER_LOG_FILE"
+	fail "Regression tests failed"
+fi
+
+echo "Success!"

--- a/examples/char_count_zig/ci/run.sh
+++ b/examples/char_count_zig/ci/run.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+#set -x
+set -o pipefail
+
+EXTENSION_NAME=char_count_zig
+
+build() {
+	echo "Build extension $EXTENSION_NAME"
+	zig build -freference-trace -p "$PG_HOME" || return 1
+}
+
+create_extension() {
+	echo "Create extension $EXTENSION_NAME"
+	psql -U postgres -c "CREATE EXTENSION IF NOT EXISTS $EXTENSION_NAME"
+}
+
+extension_drop() {
+	echo "Drop extension $EXTENSION_NAME"
+	psql -U postgres -c "DROP EXTENSION IF EXISTS $EXTENSION_NAME"
+}
+
+regression_tests() {
+	echo "Run regression tests: $EXTENSION_NAME"
+	zig build pg_regress --verbose || return 1
+}
+
+unit_tests() {
+	echo "Run unit tests: $EXTENSION_NAME"
+	zig build -freference-trace -p "$PG_HOME" unit || return 1
+}
+
+all() {
+	build && create_extension && unit_tests && regression_tests && extension_drop
+}
+
+# optional command. Use all if not specified
+command=${1:-all}
+
+#shellcheck disable=SC1007
+HELP= <<EOF
+Usage: $0 [command]
+
+commands (default 'all'):
+  all - build nand run tests
+  build - build and install extension
+  create_extension - create extension
+  extension_drop - drop extension
+  regression_tests - run regression tests
+  unit_tests - run unit tests
+  help - show this help message
+EOF
+
+case $command in
+	all) all ;;
+	build) build ;;
+	create_extension) create_extension ;;
+	extension_drop) extension_drop ;;
+	regression_tests) regression_tests ;;
+	unit_tests) unit_tests ;;
+	help) echo "$HELP" ;;
+	*) echo "$HELP" ;;
+esac

--- a/examples/pgaudit_zig/ci/run.sh
+++ b/examples/pgaudit_zig/ci/run.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+#set -x
+set -o pipefail
+
+EXTENSION_NAME=pgaudit_zig
+
+build() {
+	echo "Build extension $EXTENSION_NAME"
+	zig build -freference-trace -p "$PG_HOME" || return 1
+}
+
+create_extension() {
+	echo "Create extension $EXTENSION_NAME"
+	psql -U postgres -c "CREATE EXTENSION IF NOT EXISTS $EXTENSION_NAME"
+}
+
+extension_drop() {
+	echo "Drop extension $EXTENSION_NAME"
+	psql -U postgres -c "DROP EXTENSION IF EXISTS $EXTENSION_NAME"
+}
+
+unit_tests() {
+	echo "Run unit tests: $EXTENSION_NAME"
+	zig build -freference-trace -p "$PG_HOME" unit || return 1
+}
+
+all() {
+	build && create_extension && unit_tests && extension_drop
+}
+
+# optional command. Use all if not specified
+command=${1:-all}
+
+#shellcheck disable=SC1007
+HELP= <<EOF
+Usage: $0 [command]
+
+commands (default 'all'):
+  all - build nand run tests
+  build - build and install extension
+  create_extension - create extension
+  extension_drop - drop extension
+  unit_tests - run unit tests
+  help - show this help message
+EOF
+
+case $command in
+	all) all ;;
+	build) build ;;
+	create_extension) create_extension ;;
+	extension_drop) extension_drop ;;
+	unit_tests) unit_tests ;;
+	help) echo "$HELP" ;;
+	*) echo "$HELP" ;;
+esac

--- a/examples/spi_sql/ci/run.sh
+++ b/examples/spi_sql/ci/run.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+#set -x
+set -o pipefail
+
+EXTENSION_NAME=char_count_zig
+
+build() {
+	echo "Build extension $EXTENSION_NAME"
+	zig build -freference-trace -p "$PG_HOME" || return 1
+}
+
+create_extension() {
+	echo "Create extension $EXTENSION_NAME"
+	psql -U postgres -c "CREATE EXTENSION IF NOT EXISTS $EXTENSION_NAME"
+}
+
+extension_drop() {
+	echo "Drop extension $EXTENSION_NAME"
+	psql -U postgres -c "DROP EXTENSION IF EXISTS $EXTENSION_NAME"
+}
+
+regression_tests() {
+	echo "Run regression tests: $EXTENSION_NAME"
+	zig build pg_regress --verbose || return 1
+}
+
+all() {
+	build && create_extension && regression_tests && extension_drop
+}
+
+# optional command. Use all if not specified
+command=${1:-all}
+
+#shellcheck disable=SC1007
+HELP= <<EOF
+Usage: $0 [command]
+
+commands (default 'all'):
+  all - build nand run tests
+  build - build and install extension
+  create_extension - create extension
+  extension_drop - drop extension
+  regression_tests - run regression tests
+  help - show this help message
+EOF
+
+case $command in
+	all) all ;;
+	build) build ;;
+	create_extension) create_extension ;;
+	extension_drop) extension_drop ;;
+	regression_tests) regression_tests ;;
+	unit_tests) unit_tests ;;
+	help) echo "$HELP" ;;
+	*) echo "$HELP" ;;
+esac

--- a/examples/spi_sql/ci/run.sh
+++ b/examples/spi_sql/ci/run.sh
@@ -3,7 +3,7 @@
 #set -x
 set -o pipefail
 
-EXTENSION_NAME=char_count_zig
+EXTENSION_NAME=spi_sql
 
 build() {
 	echo "Build extension $EXTENSION_NAME"


### PR DESCRIPTION
Create a ci/run.sh script per example. Eventually we might want to provide that functionality via the zig build system as extra tasks. But there are a few things that I would like to change in the build helpers that we have before adding test runners to it.

The main ci/run.sh script will build the examples in parallel now.