### PR TITLE
pq: API improvements

### DIFF
--- a/src/pgzx/pq/conv.zig
+++ b/src/pgzx/pq/conv.zig
@@ -177,6 +177,7 @@ const textzconv = struct {
 
     pub fn write(writer: anytype, value: [:0]const u8) !void {
         _ = try writer.write(value);
+        try writer.writeByte(0);
     }
 
     pub fn parse(buf: [:0]const u8) ![:0]const u8 {


### PR DESCRIPTION
The `exec` method now accepts a list of arguments.

Add `queryX` methods that directly return `Rows` for iterating over the results (similar to the SPI interface).

Add `Rows`, `Tuple`, `Field` and descriptor types to work with the results from a query.