### PR TITLE
list: add items() method

### DIFF
--- a/src/pgzx/collections/list.zig
+++ b/src/pgzx/collections/list.zig
@@ -102,8 +102,16 @@ pub fn PointerListOf(comptime T: type) type {
             }.c_cmp);
         }
 
-        pub fn len(self: Self) usize {
+        pub inline fn len(self: Self) usize {
             return @intCast(pg.list_length(self.list));
+        }
+
+        pub fn items(self: Self) []*T {
+            if (self.list) |l| {
+                const elements: [*c]*T = @ptrCast(@alignCast(l.*.elements));
+                return elements[0..self.len()];
+            }
+            return &.{};
         }
 
         pub fn at(self: Self, n: usize) ?*T {


### PR DESCRIPTION
Add items functions that returns the underlying array. Sometimes it can be more convenient to access or iterate the elements using a normal slice.

Note: when adding elements the array can become invalid.