### PR TITLE
Build system improvements

### DIFF
--- a/examples/char_count_zig/build.zig
+++ b/examples/char_count_zig/build.zig
@@ -5,76 +5,73 @@ const std = @import("std");
 const PGBuild = @import("pgzx").Build;
 
 pub fn build(b: *std.Build) void {
-    // Project meta data
-    const name = "char_count_zig";
-    const version = .{ .major = 0, .minor = 1 };
+    const NAME = "char_count_zig";
+    const VERSION = .{ .major = 0, .minor = 1 };
 
-    const target = b.standardTargetOptions(.{});
-    const optimize = b.standardOptimizeOption(.{});
-
-    // Load the pgzx module and initialize the build utilities
-    const dep_pgzx = b.dependency("pgzx", .{ .target = target, .optimize = optimize });
-    const pgzx = dep_pgzx.module("pgzx");
-    var pgbuild = PGBuild.create(b, .{
-        .target = target,
-        .optimize = optimize,
-        .debug = .{
-            .pg_config = false,
-            .extension_dir = true,
-            .extension_lib = false,
-        },
-    });
+    const DB_TEST_USER = "postgres";
+    const DB_TEST_PORT = 5432;
 
     const build_options = b.addOptions();
     build_options.addOption(bool, "testfn", b.option(bool, "testfn", "Register test function") orelse false);
 
-    // Register the dependency with the build system
-    // and add pgzx as module dependency.
-    const ext = pgbuild.addInstallExtension(.{
-        .name = name,
-        .version = version,
-        .root_source_file = b.path("src/main.zig"),
-        .root_dir = ".",
+    var proj = PGBuild.Project.init(b, .{
+        .name = NAME,
+        .version = VERSION,
+        .root_dir = "src/",
+        .root_source_file = "src/main.zig",
     });
-    ext.lib.root_module.addImport("pgzx", pgzx);
-    ext.lib.root_module.addOptions("build_options", build_options);
+    proj.addOptions("build_options", build_options);
 
-    b.getInstallStep().dependOn(&ext.step);
+    const steps = .{
+        .check = b.step("check", "Check if project compiles"),
+        .install = b.getInstallStep(),
+        .pg_regress = b.step("pg_regress", "Run regression tests"),
+        .unit = b.step("unit", "Run unit tests"),
+    };
 
-    // Configure pg_regress based testing for the current extension.
-    const extest = pgbuild.addRegress(.{
-        .db_user = "postgres",
-        .db_port = 5432,
-        .root_dir = ".",
-        .scripts = &[_][]const u8{
-            "char_count_test",
-        },
-    });
+    { // build and install extension
+        steps.install.dependOn(&proj.installExtensionLib().step);
+        steps.install.dependOn(&proj.installExtensionDir().step);
+    }
 
-    // Make regression tests available to `zig build`
-    var regress = b.step("pg_regress", "Run regression tests");
-    regress.dependOn(&extest.step);
+    { // check extension Zig source code only. No linkage or installation for faster development.
+        const lib = proj.extensionLib();
+        lib.linkage = null;
+        steps.check.dependOn(&lib.step);
+    }
 
-    // Extension build for unit tests. Same as above, but with testfn for sure true.
-    const test_options = b.addOptions();
-    test_options.addOption(bool, "testfn", true);
-    const test_ext = pgbuild.addInstallExtension(.{
-        .name = name,
-        .version = version,
-        .root_source_file = b.path("src/main.zig"),
-        .root_dir = ".",
-    });
-    test_ext.lib.root_module.addImport("pgzx", pgzx);
-    test_ext.lib.root_module.addOptions("build_options", test_options);
+    { // pg_regress tests (regression tests use the default build)
+        var regress = proj.pgbuild.addRegress(.{
+            .db_user = DB_TEST_USER,
+            .db_port = DB_TEST_PORT,
+            .root_dir = ".",
+            .scripts = &[_][]const u8{
+                "char_count_test",
+            },
+        });
+        regress.step.dependOn(steps.install);
 
-    // Step for running the unit tests.
-    const psql_run_tests = pgbuild.addRunTests(.{
-        .name = name,
-        .db_user = "postgres",
-        .db_port = 5432,
-    });
-    psql_run_tests.step.dependOn(&test_ext.step);
+        steps.pg_regress.dependOn(&regress.step);
+    }
 
-    var unit = b.step("unit", "Run unit tests");
-    unit.dependOn(&psql_run_tests.step);
+    { // unit testing. We install an alternative version of the lib build with test_fn = true
+        const test_options = b.addOptions();
+        test_options.addOption(bool, "testfn", true);
+
+        const lib = proj.extensionLib();
+        lib.root_module.addOptions("build_options", test_options);
+
+        // Step for running the unit tests.
+        const psql_run_tests = proj.pgbuild.addRunTests(.{
+            .name = NAME,
+            .db_user = DB_TEST_USER,
+            .db_port = DB_TEST_PORT,
+        });
+
+        // Build and install extension before running the tests.
+        psql_run_tests.step.dependOn(&proj.pgbuild.addInstallExtensionLibArtifact(lib, NAME).step);
+        psql_run_tests.step.dependOn(&proj.installExtensionLib().step);
+
+        steps.unit.dependOn(&psql_run_tests.step);
+    }
 }

--- a/examples/spi_sql/build.zig
+++ b/examples/spi_sql/build.zig
@@ -41,7 +41,7 @@ pub fn build(b: *std.Build) void {
             .db_port = DB_TEST_PORT,
             .root_dir = ".",
             .scripts = &[_][]const u8{
-                "char_count_test",
+                "spi_sql_test",
             },
         });
         regress.step.dependOn(steps.install);

--- a/examples/spi_sql/build.zig
+++ b/examples/spi_sql/build.zig
@@ -5,49 +5,47 @@ const std = @import("std");
 const PGBuild = @import("pgzx").Build;
 
 pub fn build(b: *std.Build) void {
-    // Project meta data
-    const name = "spi_sql";
-    const version = .{ .major = 0, .minor = 1 };
+    const NAME = "spi_sql";
+    const VERSION = .{ .major = 0, .minor = 1 };
 
-    const target = b.standardTargetOptions(.{});
-    const optimize = b.standardOptimizeOption(.{});
+    const DB_TEST_USER = "postgres";
+    const DB_TEST_PORT = 5432;
 
-    // Load the pgzx module and initialize the build utilities
-    const dep_pgzx = b.dependency("pgzx", .{ .target = target, .optimize = optimize });
-    const pgzx = dep_pgzx.module("pgzx");
-    var pgbuild = PGBuild.create(b, .{ .target = target, .optimize = optimize });
+    const proj = PGBuild.Project.init(b, .{
+        .name = NAME,
+        .version = VERSION,
+        .root_dir = "src/",
+        .root_source_file = "src/main.zig",
+    });
 
-    const build_options = b.addOptions();
-    build_options.addOption(bool, "testfn", b.option(bool, "testfn", "Register test function") orelse false);
+    const steps = .{
+        .check = b.step("check", "Check if project compiles"),
+        .install = b.getInstallStep(),
+        .pg_regress = b.step("pg_regress", "Run regression tests"),
+    };
 
-    // Register the dependency with the build system
-    // and add pgzx as module dependency.
-    {
-        const ext = pgbuild.addInstallExtension(.{
-            .name = name,
-            .version = version,
-            .root_source_file = b.path("src/main.zig"),
-            .root_dir = ".",
-        });
-        ext.lib.root_module.addImport("pgzx", pgzx);
-        ext.lib.root_module.addOptions("build_options", build_options);
-
-        b.getInstallStep().dependOn(&ext.step);
+    { // build and install extension
+        steps.install.dependOn(&proj.installExtensionLib().step);
+        steps.install.dependOn(&proj.installExtensionDir().step);
     }
 
-    // Configure pg_regress based testing for the current extension.
-    {
-        const extest = pgbuild.addRegress(.{
-            .db_user = "postgres",
-            .db_port = 5432,
+    { // check extension Zig source code only. No linkage or installation for faster development.
+        const lib = proj.extensionLib();
+        lib.linkage = null;
+        steps.check.dependOn(&lib.step);
+    }
+
+    { // pg_regress tests (regression tests use the default build)
+        const regress = proj.pgbuild.addRegress(.{
+            .db_user = DB_TEST_USER,
+            .db_port = DB_TEST_PORT,
             .root_dir = ".",
             .scripts = &[_][]const u8{
-                "spi_sql_test",
+                "char_count_test",
             },
         });
+        regress.step.dependOn(steps.install);
 
-        // Make regression tests available to `zig build`
-        var regress = b.step("pg_regress", "Run regression tests");
-        regress.dependOn(&extest.step);
+        steps.pg_regress.dependOn(&regress.step);
     }
 }

--- a/examples/sqlfns/build.zig
+++ b/examples/sqlfns/build.zig
@@ -5,49 +5,47 @@ const std = @import("std");
 const PGBuild = @import("pgzx").Build;
 
 pub fn build(b: *std.Build) void {
-    // Project meta data
-    const name = "sqlfns";
-    const version = .{ .major = 0, .minor = 1 };
+    const NAME = "sqlfns";
+    const VERSION = .{ .major = 0, .minor = 1 };
 
-    const target = b.standardTargetOptions(.{});
-    const optimize = b.standardOptimizeOption(.{});
+    const DB_TEST_USER = "postgres";
+    const DB_TEST_PORT = 5432;
 
-    // Load the pgzx module and initialize the build utilities
-    const dep_pgzx = b.dependency("pgzx", .{ .target = target, .optimize = optimize });
-    const pgzx = dep_pgzx.module("pgzx");
-    var pgbuild = PGBuild.create(b, .{ .target = target, .optimize = optimize });
+    const proj = PGBuild.Project.init(b, .{
+        .name = NAME,
+        .version = VERSION,
+        .root_dir = "src/",
+        .root_source_file = "src/main.zig",
+    });
 
-    const build_options = b.addOptions();
-    build_options.addOption(bool, "testfn", b.option(bool, "testfn", "Register test function") orelse false);
+    const steps = .{
+        .check = b.step("check", "Check if project compiles"),
+        .install = b.getInstallStep(),
+        .pg_regress = b.step("pg_regress", "Run regression tests"),
+    };
 
-    // Register the dependency with the build system
-    // and add pgzx as module dependency.
-    {
-        const ext = pgbuild.addInstallExtension(.{
-            .name = name,
-            .version = version,
-            .root_source_file = b.path("src/main.zig"),
-            .root_dir = ".",
-        });
-        ext.lib.root_module.addImport("pgzx", pgzx);
-        ext.lib.root_module.addOptions("build_options", build_options);
-
-        b.getInstallStep().dependOn(&ext.step);
+    { // build and install extension
+        steps.install.dependOn(&proj.installExtensionLib().step);
+        steps.install.dependOn(&proj.installExtensionDir().step);
     }
 
-    // Configure pg_regress based testing for the current extension.
-    {
-        const extest = pgbuild.addRegress(.{
-            .db_user = "postgres",
-            .db_port = 5432,
+    { // check extension Zig source code only. No linkage or installation for faster development.
+        const lib = proj.extensionLib();
+        lib.linkage = null;
+        steps.check.dependOn(&lib.step);
+    }
+
+    { // pg_regress tests (regression tests use the default build)
+        const regress = proj.pgbuild.addRegress(.{
+            .db_user = DB_TEST_USER,
+            .db_port = DB_TEST_PORT,
             .root_dir = ".",
             .scripts = &[_][]const u8{
-                "sqlfns_test",
+                "char_count_test",
             },
         });
+        regress.step.dependOn(steps.install);
 
-        // Make regression tests available to `zig build`
-        var regress = b.step("pg_regress", "Run regression tests");
-        regress.dependOn(&extest.step);
+        steps.pg_regress.dependOn(&regress.step);
     }
 }

--- a/examples/sqlfns/build.zig
+++ b/examples/sqlfns/build.zig
@@ -41,7 +41,7 @@ pub fn build(b: *std.Build) void {
             .db_port = DB_TEST_PORT,
             .root_dir = ".",
             .scripts = &[_][]const u8{
-                "char_count_test",
+                "sqlfns_test",
             },
         });
         regress.step.dependOn(steps.install);

--- a/src/pgzx/build.zig
+++ b/src/pgzx/build.zig
@@ -3,13 +3,123 @@ const std = @import("std");
 const Step = std.Build.Step;
 const LazyPath = std.Build.LazyPath;
 
+const Build = @This();
+
 std_build: *std.Build,
 paths: Paths,
-target: std.Build.ResolvedTarget,
-optimize: std.builtin.Mode,
+options: struct {
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.Mode,
+},
 debug: DebugOptions,
 
-const Build = @This();
+modules: struct {
+    builder: *Build = undefined,
+
+    const Self = @This();
+
+    fn loadModule(mods: Self, name: []const u8) *std.Build.Module {
+        const dep = mods.builder.std_build.dependency("pgzx", mods.builder.options);
+        return dep.module(name);
+    }
+
+    pub fn pgzx(mods: Self) *std.Build.Module {
+        return mods.loadModule("pgzx");
+    }
+
+    pub fn pgsys(mods: Self) *std.Build.Module {
+        return mods.loadModule("pgsys");
+    }
+},
+
+// We use project to collect common build optoins and resources.
+//
+// When creating the docs or build and install steps, `Compile` step is
+// directly configured to emit these kind of resources. Because we do not
+// always want to emit everything we are forced to create separate `Compile`
+// step instances for the different commands we want to run. The `Project`
+// struct helps us to create properly configured resources, including
+// dependencies.
+//
+pub const Project = struct {
+    pgbuild: *Build,
+    build: *std.Build,
+    deps: struct {
+        pgzx: *std.Build.Module,
+    },
+    options: std.StringArrayHashMapUnmanaged(*Step.Options),
+    config: Config,
+
+    pub const Config = struct {
+        name: []const u8,
+        version: ExtensionVersion,
+
+        root_dir: []const u8,
+        root_source_file: ?[]const u8 = null,
+
+        extension_dir: ?[]const u8 = null,
+    };
+
+    pub fn init(b: *std.Build, c: Config) Project {
+        const pgbuild = Build.create(b, .{
+            .target = b.standardTargetOptions(.{}),
+            .optimize = b.standardOptimizeOption(.{}),
+            .debug = .{
+                .pg_config = false,
+                .extension_lib = false,
+            },
+        });
+
+        var proj_config = c;
+        if (c.root_source_file == null) {
+            const file_name = std.fmt.allocPrint(b.allocator, "{s}.zig", .{c.name}) catch unreachable;
+            const src: []u8 = std.fs.path.join(b.allocator, &[_][]const u8{ c.root_dir, file_name }) catch unreachable;
+            proj_config.root_source_file = src;
+        }
+        if (c.extension_dir == null) {
+            proj_config.extension_dir = "./extension/";
+        }
+
+        return Project{
+            .build = b,
+            .pgbuild = pgbuild,
+            .deps = .{
+                .pgzx = pgbuild.modules.pgzx(),
+            },
+            .config = proj_config,
+            .options = std.StringArrayHashMapUnmanaged(*Step.Options).init(b.allocator, &.{}, &.{}) catch unreachable,
+        };
+    }
+
+    pub fn extensionLib(proj: Project) *Step.Compile {
+        const lib = proj.pgbuild.addExtensionLib(.{
+            .name = proj.config.name,
+            .version = proj.config.version,
+            .root_dir = proj.config.root_dir,
+            .root_source_file = proj.build.path(proj.config.root_source_file.?),
+        });
+        lib.root_module.addImport("pgzx", proj.deps.pgzx);
+
+        var it = proj.options.iterator();
+        while (it.next()) |kv| {
+            lib.root_module.addOptions(kv.key_ptr.*, kv.value_ptr.*);
+        }
+
+        return lib;
+    }
+
+    pub fn installExtensionLib(proj: Project) *Step.InstallFile {
+        return proj.pgbuild.addInstallExtensionLibArtifact(proj.extensionLib(), proj.config.name);
+    }
+
+    pub fn installExtensionDir(proj: Project) *Step.InstallDir {
+        return proj.pgbuild.addInstallExtensionDir(proj.config.extension_dir.?);
+    }
+
+    pub fn addOptions(proj: *Project, module_name: []const u8, options: *Step.Options) void {
+        proj.options.put(proj.build.allocator, module_name, options) catch unreachable;
+    }
+};
 
 pub const DebugOptions = struct {
     pg_config: bool = false,
@@ -60,82 +170,44 @@ pub const InstallExtension = struct {
     };
 
     pub fn create(b: *Build, options: Options) *InstallExtension {
-        const PGIncludeServerDir: LazyPath = .{
-            .cwd_relative = b.getIncludeServerDir(),
-        };
-
         const root_dir = options.root_dir orelse
             b.std_build.pathJoin(&[_][]const u8{ "src/", options.name });
 
-        const lib = blk: {
-            const lib = b.std_build.addSharedLibrary(.{
-                .name = options.name,
-                .version = .{
-                    .major = options.version.major,
-                    .minor = options.version.minor,
-                    .patch = 0,
-                },
-                .root_source_file = resolveLazyPath(b, root_dir, options.root_source_file, "main.zig"),
-                .target = options.target orelse b.target,
-                .optimize = options.optimize orelse b.optimize,
-                .link_libc = options.link_libc,
-            });
-            lib.addIncludePath(PGIncludeServerDir);
-            lib.linker_allow_shlib_undefined = options.link_allow_shlib_undefined;
-            break :blk lib;
-        };
+        const lib = b.addExtensionLib(.{
+            .name = options.name,
+            .version = options.version,
+            .root_dir = root_dir,
+            .root_source_file = options.root_source_file,
+            .link_libc = options.link_libc,
+        });
 
         const extension_dir = b.addInstallExtensionDir(
             resolvePath(b, root_dir, options.extension_dir, "extension") orelse @panic("root_dir or extension_dir"),
         );
 
-        var step = Step.init(.{
-            .id = .custom,
-            .name = "install extension",
-            .owner = b.std_build,
-        });
-        step.dependOn(&b.addInstallExtensionLibArtifact(lib, options.name).step);
-        step.dependOn(&extension_dir.step);
-
-        const self = b.std_build.allocator.create(InstallExtension) catch @panic("OOM");
-        self.* = .{
+        const install_ext = b.std_build.allocator.create(InstallExtension) catch @panic("OOM");
+        install_ext.* = .{
             .lib = lib,
-            .step = step,
+            .step = b.joinSteps("install_extension", .{
+                &b.addInstallExtensionLibArtifact(lib, options.name).step,
+                &extension_dir.step,
+            }),
             .extension_dir = extension_dir,
         };
-        return self;
-    }
-
-    fn resolveLazyPath(b: *Build, root_dir: []const u8, p: ?LazyPath, comptime default: []const u8) ?LazyPath {
-        if (p) |configured_path| {
-            return configured_path;
-        }
-        if (resolvePath(b, root_dir, null, default)) |path| {
-            return .{
-                .cwd_relative = path,
-            };
-        }
-        return null;
-    }
-
-    fn resolvePath(b: *Build, root_dir: []const u8, p: ?[]const u8, default: []const u8) ?[]const u8 {
-        if (p) |configured_path| {
-            return configured_path;
-        }
-        return b.std_build.pathJoin(&[_][]const u8{ root_dir, default });
+        return install_ext;
     }
 };
 
-const Run = struct {
+pub const RunExec = struct {
     owner: *Build,
     argv: std.ArrayList([]const u8),
     step: Step,
 
     pub const base_id: Step.Id = .run;
 
-    fn create(b: *Build, name: []const u8, argv: []const []const u8) *Run {
-        var self = b.std_build.allocator.create(Run) catch @panic("OOM");
-        self.* = .{
+    fn create(b: *Build, name: []const u8, argv: []const []const u8) *RunExec {
+        var r = b.std_build.allocator.create(RunExec) catch @panic("OOM");
+        r.* = .{
             .owner = b,
             .argv = std.ArrayList([]const u8).init(b.std_build.allocator),
             .step = Step.init(.{
@@ -145,37 +217,37 @@ const Run = struct {
                 .makeFn = make,
             }),
         };
-        self.argv.appendSlice(argv) catch @panic("OOM");
-        return self;
+        r.argv.appendSlice(argv) catch @panic("OOM");
+        return r;
     }
 
-    fn addArg(self: *Run, arg: []const u8) void {
-        self.argv.append(arg) catch @panic("OOM");
+    fn addArg(r: *RunExec, arg: []const u8) void {
+        r.argv.append(arg) catch @panic("OOM");
     }
 
-    fn addArgOption(self: *Run, option: []const u8, arg: []const u8) void {
-        self.addArg(option);
-        self.addArg(arg);
+    fn addArgOption(r: *RunExec, option: []const u8, arg: []const u8) void {
+        r.addArg(option);
+        r.addArg(arg);
     }
 
-    fn addArgs(self: *Run, args: []const []const u8) void {
+    fn addArgs(r: *RunExec, args: []const []const u8) void {
         for (args) |arg| {
-            self.addArg(arg);
+            r.addArg(arg);
         }
     }
 
-    fn hasSideEffects(self: Run) bool {
-        _ = self;
+    fn hasSideEffects(r: RunExec) bool {
+        _ = r;
         return true;
     }
 
     fn make(step: *Step, prog_node: std.Progress.Node) anyerror!void {
         _ = prog_node;
 
-        const self: *Run = @fieldParentPtr("step", step);
-        const b = self.owner.std_build;
+        const r: *RunExec = @fieldParentPtr("step", step);
+        const b = r.owner.std_build;
 
-        var child = std.process.Child.init(self.argv.items, b.allocator);
+        var child = std.process.Child.init(r.argv.items, b.allocator);
         child.cwd = b.build_root.path;
         child.cwd_dir = b.build_root.handle;
         child.stdin_behavior = .Ignore;
@@ -187,67 +259,8 @@ const Run = struct {
             else => @panic("process failed"),
         };
         if (exit_code != 0) {
-            return step.fail("{s} failed. Exit code: {d}\n", .{ self.step.name, exit_code });
+            return step.fail("{s} failed. Exit code: {d}\n", .{ r.step.name, exit_code });
         }
-    }
-};
-
-pub const RunRegress = struct {
-    pub const Options = struct {
-        scripts: []const []const u8,
-        root_dir: []const u8,
-
-        db_user: ?[]const u8 = null,
-        db_host: ?[]const u8 = null,
-        db_port: ?u16 = null,
-        db_name: ?[]const u8 = null,
-        debug: bool = false,
-        create_role: ?[]const u8 = null,
-        load_extensions: ?[]const []const u8 = null,
-    };
-
-    pub fn create(b: *Build, options: Options) *Run {
-        const pg_regress_tool = b.getPGRegressPath();
-        const root_dir = options.root_dir;
-        var runner = Run.create(b, "pg_regress", &[_][]const u8{
-            pg_regress_tool,
-            "--inputdir",
-            root_dir,
-            "--outputdir",
-            root_dir,
-            "--expecteddir",
-            root_dir,
-        });
-
-        if (options.db_host) |db_host| {
-            runner.addArgs(&[_][]const u8{ "--host", db_host });
-        }
-        if (options.db_port) |db_port| {
-            runner.addArgs(&[_][]const u8{
-                "--port",
-                std.fmt.allocPrint(b.std_build.allocator, "{d}", .{db_port}) catch @panic("OOM"),
-            });
-        }
-        if (options.db_user) |db_user| {
-            runner.addArgs(&[_][]const u8{ "--user", db_user });
-        }
-        if (options.db_name) |db_name| {
-            runner.addArgs(&[_][]const u8{ "--dbname", db_name });
-        }
-        if (options.create_role) |create_role| {
-            runner.addArgs(&[_][]const u8{ "--create-role", create_role });
-        }
-        if (options.debug) {
-            runner.addArgs(&[_][]const u8{"--debug"});
-        }
-        if (options.load_extensions) |list| {
-            for (list) |ext| {
-                runner.addArgs(&[_][]const u8{ "--load-extension", ext });
-            }
-        }
-
-        runner.addArgs(options.scripts);
-        return runner;
     }
 };
 
@@ -266,7 +279,7 @@ pub const RunTests = struct {
         db_name: ?[]const u8 = null,
     };
 
-    pub fn create(b: *Build, options: Options) *Run {
+    pub fn create(b: *Build, options: Options) *RunExec {
         const sql = std.fmt.allocPrint(
             b.std_build.allocator,
             \\ DROP FUNCTION IF EXISTS run_tests;
@@ -276,7 +289,7 @@ pub const RunTests = struct {
             .{options.name},
         ) catch @panic("OOM");
         const psql_exe = b.getPsqlPath();
-        var runner = Run.create(b, "run_tests_psql", &[_][]const u8{
+        var runner = RunExec.create(b, "run_tests_psql", &[_][]const u8{
             psql_exe,
             "-c",
             sql,
@@ -301,80 +314,113 @@ pub const RunTests = struct {
     }
 };
 
-pub const SharedLibraryExtension = struct {};
-
 pub const InitOptions = struct {
     target: std.Build.ResolvedTarget,
     optimize: std.builtin.Mode,
     debug: DebugOptions = .{},
 };
 
-pub fn create(b: *std.Build, options: InitOptions) *Build {
-    const self = b.allocator.create(Build) catch @panic("OOM");
-    self.* = .{
-        .std_build = b,
+pub fn create(std_build: *std.Build, options: InitOptions) *Build {
+    const b = std_build.allocator.create(Build) catch @panic("OOM");
+    b.* = .{
+        .std_build = std_build,
         .paths = .{},
-        .target = options.target,
-        .optimize = options.optimize,
+        .options = .{
+            .target = options.target,
+            .optimize = options.optimize,
+        },
         .debug = options.debug,
+        .modules = .{},
     };
-    return self;
+    b.*.modules.builder = b;
+    return b;
 }
 
-pub fn getIncludeDir(self: *Build) []const u8 {
-    return self.getPath(&self.paths.include_dir, "--includedir", false);
+pub fn getIncludeDir(b: *Build) []const u8 {
+    return b.getPath(&b.paths.include_dir, "--includedir", false);
 }
 
-pub fn getIncludeServerDir(self: *Build) []const u8 {
-    return self.getPath(&self.paths.include_server_dir, "--includedir-server", false);
+pub fn getIncludeServerDir(b: *Build) []const u8 {
+    return b.getPath(&b.paths.include_server_dir, "--includedir-server", false);
 }
 
-pub fn getPackageLibDir(self: *Build) []const u8 {
-    return self.getPath(&self.paths.package_lib_dir, "--pkglibdir", false);
+pub fn getPackageLibDir(b: *Build) []const u8 {
+    return b.getPath(&b.paths.package_lib_dir, "--pkglibdir", false);
 }
 
-pub fn getLibDir(self: *Build) []const u8 {
-    return self.getPath(&self.paths.lib_dir, "--libdir", false);
+pub fn getLibDir(b: *Build) []const u8 {
+    return b.getPath(&b.paths.lib_dir, "--libdir", false);
 }
-pub fn getSharedDir(self: *Build) []const u8 {
-    return self.getPath(&self.paths.shared_dir, "--sharedir", true);
-}
-
-pub fn getBinDir(self: *Build) []const u8 {
-    return self.getPath(&self.paths.bin_dir, "--bindir", false);
+pub fn getSharedDir(b: *Build) []const u8 {
+    return b.getPath(&b.paths.shared_dir, "--sharedir", true);
 }
 
-pub fn getExtensionDir(self: *Build) []const u8 {
-    self.paths.extension_dir = self.paths.extension_dir orelse blk: {
-        const shared = self.getSharedDir();
-        break :blk self.std_build.pathJoin(&[_][]const u8{ shared, "extension" });
+pub fn getBinDir(b: *Build) []const u8 {
+    return b.getPath(&b.paths.bin_dir, "--bindir", false);
+}
+
+pub fn getExtensionDir(b: *Build) []const u8 {
+    b.paths.extension_dir = b.paths.extension_dir orelse blk: {
+        const shared = b.getSharedDir();
+        break :blk b.std_build.pathJoin(&[_][]const u8{ shared, "extension" });
     };
-    return self.paths.extension_dir.?;
+    return b.paths.extension_dir.?;
 }
 
-pub fn getPGRegressPath(self: *Build) []const u8 {
-    self.paths.pg_regress_path = self.paths.pg_regress_path orelse blk: {
-        const pkglib = self.getPackageLibDir();
+pub fn getPGRegressPath(b: *Build) []const u8 {
+    b.paths.pg_regress_path = b.paths.pg_regress_path orelse blk: {
+        const pkglib = b.getPackageLibDir();
         const pg_regress = "pgxs/src/test/regress/pg_regress";
-        break :blk self.std_build.pathJoin(&[_][]const u8{ pkglib, pg_regress });
+        break :blk b.std_build.pathJoin(&[_][]const u8{ pkglib, pg_regress });
     };
-    return self.paths.pg_regress_path.?;
+    return b.paths.pg_regress_path.?;
 }
 
-pub fn getPsqlPath(self: *Build) []const u8 {
-    self.paths.psql_path = self.paths.psql_path orelse blk: {
-        const bin_dir = self.getBinDir();
-        break :blk self.std_build.pathJoin(&[_][]const u8{ bin_dir, "psql" });
+pub fn getPsqlPath(b: *Build) []const u8 {
+    b.paths.psql_path = b.paths.psql_path orelse blk: {
+        const bin_dir = b.getBinDir();
+        break :blk b.std_build.pathJoin(&[_][]const u8{ bin_dir, "psql" });
     };
-    return self.paths.psql_path.?;
+    return b.paths.psql_path.?;
 }
 
-pub fn installSharedLibExtension(self: *Build, artifact: *Step.Compile, ext_path: []const u8) void {
-    self.std_build.getInstallStep().dependOn(&self.std_build.addInstallArtifact(artifact, .{
+const ExtensionLibOptions = struct {
+    name: []const u8,
+    version: ExtensionVersion,
+    root_dir: ?[]const u8 = null,
+    root_source_file: ?LazyPath = null,
+    link_libc: bool = true,
+};
+
+pub fn addExtensionLib(b: *Build, options: ExtensionLibOptions) *Step.Compile {
+    const root_dir = options.root_dir orelse
+        b.std_build.pathJoin(&[_][]const u8{ "src/", options.name });
+
+    const lib = b.std_build.addSharedLibrary(.{
+        .name = options.name,
+        .version = .{
+            .major = options.version.major,
+            .minor = options.version.minor,
+            .patch = 0,
+        },
+        .root_source_file = b.resolveLazyPath(root_dir, options.root_source_file, "main.zig"),
+        .target = b.options.target,
+        .optimize = b.options.optimize,
+        .link_libc = options.link_libc,
+    });
+    lib.addIncludePath(.{
+        .cwd_relative = b.getIncludeServerDir(),
+    });
+    lib.linker_allow_shlib_undefined = true;
+    return lib;
+}
+
+pub fn installSharedLibExtension(b: *Build, artifact: *Step.Compile, ext_path: []const u8) void {
+    b.std_build.getInstallStep().dependOn(&b.std_build.addInstallArtifact(artifact, .{
         .dest_dir = .{
             .override = .{
-                .custom = self.std_build.pathJoin(&[_][]const u8{
-                    self.getLibDir(),
+                .custom = b.std_build.pathJoin(&[_][]const u8{
+                    b.getLibDir(),
                     ext_path,
                 }),
             },
@@ -382,25 +428,25 @@ pub fn installSharedLibExtension(self: *Build, artifact: *Step.Compile, ext_path
     }).step);
 }
 
-pub fn addInstallExtension(self: *Build, options: InstallExtension.Options) *InstallExtension {
-    return InstallExtension.create(self, options);
+pub fn addInstallExtension(b: *Build, options: InstallExtension.Options) *InstallExtension {
+    return InstallExtension.create(b, options);
 }
 
-pub fn installExtension(self: *Build, options: InstallExtension.Options) *InstallExtension {
-    const ext = self.addInstallExtension(options);
-    self.std_build.getInstallStep().dependOn(&ext.step);
+pub fn installExtension(b: *Build, options: InstallExtension.Options) *InstallExtension {
+    const ext = b.addInstallExtension(options);
+    b.std_build.getInstallStep().dependOn(&ext.step);
     return ext;
 }
 
-pub fn installExtensionLibArtifact(self: *Build, artifact: *Step.Compile, name: []const u8) *Step.InstallFile {
-    const file_artifact = self.addInstallExtensionLibArtifact(artifact, name);
-    self.std_build.getInstallStep().dependOn(&file_artifact.step);
+pub fn installExtensionLibArtifact(b: *Build, artifact: *Step.Compile, name: []const u8) *Step.InstallFile {
+    const file_artifact = b.addInstallExtensionLibArtifact(artifact, name);
+    b.std_build.getInstallStep().dependOn(&file_artifact.step);
     return file_artifact;
 }
 
-pub fn addInstallExtensionLibArtifact(self: *Build, artifact: *Step.Compile, name: []const u8) *Step.InstallFile {
+pub fn addInstallExtensionLibArtifact(b: *Build, artifact: *Step.Compile, name: []const u8) *Step.InstallFile {
     const lib_suffix = artifact.rootModuleTarget().dynamicLibSuffix();
-    const plugin_name = std.fmt.allocPrint(self.std_build.allocator, "{s}{s}", .{ name, lib_suffix }) catch @panic("OOM");
+    const plugin_name = std.fmt.allocPrint(b.std_build.allocator, "{s}{s}", .{ name, lib_suffix }) catch @panic("OOM");
 
     // TODO: resolve paths to ensures they are canonicalized.
 
@@ -413,17 +459,17 @@ pub fn addInstallExtensionLibArtifact(self: *Build, artifact: *Step.Compile, nam
     // installation prefix is indeed the local postgres installation path.
     // Otherwise we force the shared library to be copied to the prefix path
     // directly (no sub folders).
-    const pg_home = self.getPGHome();
-    const package_lib_dir = self.getPackageLibDir();
-    const is_deploy = std.mem.eql(u8, self.std_build.install_prefix, pg_home);
+    const pg_home = b.getPGHome();
+    const package_lib_dir = b.getPackageLibDir();
+    const is_deploy = std.mem.eql(u8, b.std_build.install_prefix, pg_home);
     const target_lib_dir = if (is_deploy or std.mem.startsWith(u8, package_lib_dir, pg_home))
-        self.makeRelPath(package_lib_dir)
+        b.makeRelPath(package_lib_dir)
     else
         ".";
 
     const artifact_file = artifact.getEmittedBin();
-    if (self.debug.extension_lib) {
-        std.debug.print("pg_home: {s}\n", .{self.getPGHome()});
+    if (b.debug.extension_lib) {
+        std.debug.print("pg_home: {s}\n", .{b.getPGHome()});
         std.debug.print("Package lib dir: {s}\n", .{package_lib_dir});
 
         std.debug.print("Configure step: install extension lib: {s} -> {s}/{s}\n", .{
@@ -433,57 +479,110 @@ pub fn addInstallExtensionLibArtifact(self: *Build, artifact: *Step.Compile, nam
         });
     }
 
-    return self.std_build.addInstallFileWithDir(
+    return b.std_build.addInstallFileWithDir(
         artifact_file,
         .{ .custom = target_lib_dir },
         plugin_name,
     );
 }
 
-pub fn addInstallExtensionDir(self: *Build, source_dir: []const u8) *Step.InstallDir {
-    const source_dir_path = self.std_build.path(source_dir);
-    const ext_dir = self.getExtensionDir();
+pub fn addInstallExtensionDir(b: *Build, source_dir: []const u8) *Step.InstallDir {
+    const source_dir_path = b.std_build.path(source_dir);
+    const ext_dir = b.getExtensionDir();
 
-    if (self.debug.extension_dir) {
+    if (b.debug.extension_dir) {
         std.debug.print("Configure step: install extension dir: {s} -> {s}\n", .{ source_dir, ext_dir });
     }
 
-    return self.std_build.addInstallDirectory(.{
+    return b.std_build.addInstallDirectory(.{
         .source_dir = source_dir_path,
         .install_dir = .prefix,
         .install_subdir = ext_dir,
     });
 }
 
-pub fn installExtensionDir(self: *Build, source_dir: []const u8) void {
-    self.std_build.getInstallStep().dependOn(&self.addInstallExtensionDir(source_dir).step);
+pub fn installExtensionDir(b: *Build, source_dir: []const u8) void {
+    b.std_build.getInstallStep().dependOn(&b.addInstallExtensionDir(source_dir).step);
 }
 
-pub fn addRegress(self: *Build, options: RunRegress.Options) *Run {
-    return RunRegress.create(self, options);
+pub const PGRegressOptions = struct {
+    scripts: []const []const u8,
+    root_dir: []const u8,
+
+    db_user: ?[]const u8 = null,
+    db_host: ?[]const u8 = null,
+    db_port: ?u16 = null,
+    db_name: ?[]const u8 = null,
+    debug: bool = false,
+    create_role: ?[]const u8 = null,
+    load_extensions: ?[]const []const u8 = null,
+};
+
+pub fn addRegress(b: *Build, options: PGRegressOptions) *RunExec {
+    const pg_regress_tool = b.getPGRegressPath();
+    const root_dir = options.root_dir;
+    var runner = RunExec.create(b, "pg_regress", &[_][]const u8{
+        pg_regress_tool,
+        "--inputdir",
+        root_dir,
+        "--outputdir",
+        root_dir,
+        "--expecteddir",
+        root_dir,
+    });
+
+    if (options.db_host) |db_host| {
+        runner.addArgs(&[_][]const u8{ "--host", db_host });
+    }
+    if (options.db_port) |db_port| {
+        runner.addArgs(&[_][]const u8{
+            "--port",
+            std.fmt.allocPrint(b.std_build.allocator, "{d}", .{db_port}) catch @panic("OOM"),
+        });
+    }
+    if (options.db_user) |db_user| {
+        runner.addArgs(&[_][]const u8{ "--user", db_user });
+    }
+    if (options.db_name) |db_name| {
+        runner.addArgs(&[_][]const u8{ "--dbname", db_name });
+    }
+    if (options.create_role) |create_role| {
+        runner.addArgs(&[_][]const u8{ "--create-role", create_role });
+    }
+    if (options.debug) {
+        runner.addArgs(&[_][]const u8{"--debug"});
+    }
+    if (options.load_extensions) |list| {
+        for (list) |ext| {
+            runner.addArgs(&[_][]const u8{ "--load-extension", ext });
+        }
+    }
+
+    runner.addArgs(options.scripts);
+    return runner;
 }
 
-pub fn addRunTests(self: *Build, options: RunTests.Options) *Run {
+pub fn addRunTests(self: *Build, options: RunTests.Options) *RunExec {
     return RunTests.create(self, options);
 }
 
-fn getPath(self: *Build, path: *?[]const u8, question: []const u8, relative: bool) []const u8 {
+fn getPath(b: *Build, path: *?[]const u8, question: []const u8, relative: bool) []const u8 {
     path.* = path.* orelse blk: {
-        var p = self.runPGConfig(question);
+        var p = b.runPGConfig(question);
         if (relative) {
-            p = self.makeRelPath(p);
+            p = b.makeRelPath(p);
         }
         break :blk p;
     };
     return path.*.?;
 }
 
-fn makeRelPath(self: *Build, path: []const u8) []const u8 {
-    const cwd = self.getPGHome();
-    return std.fs.path.relative(self.std_build.allocator, cwd, path) catch @panic("failed to make relative path");
+fn makeRelPath(b: *Build, path: []const u8) []const u8 {
+    const cwd = b.getPGHome();
+    return std.fs.path.relative(b.std_build.allocator, cwd, path) catch @panic("failed to make relative path");
 }
 
-pub fn runPGConfig(self: *Build, question: []const u8) []const u8 {
+pub fn runPGConfig(b: *Build, question: []const u8) []const u8 {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -493,7 +592,7 @@ pub fn runPGConfig(self: *Build, question: []const u8) []const u8 {
         question,
     };
 
-    if (self.debug.pg_config) {
+    if (b.debug.pg_config) {
         std.debug.print("Running pg_config: {s}\n", .{argv});
     }
 
@@ -515,20 +614,20 @@ pub fn runPGConfig(self: *Build, question: []const u8) []const u8 {
         @panic("pg_config failed");
     }
 
-    if (self.debug.pg_config) {
+    if (b.debug.pg_config) {
         std.debug.print("pg_config returned: {s}\n", .{path});
     }
 
     // Copy the result onto the builders allocator
-    return self.std_build.dupe(path);
+    return b.std_build.dupe(path);
 }
 
-pub fn getPGHome(self: *Build) []const u8 {
-    self.paths.pg_home = self.paths.pg_home orelse blk: {
-        const bindir = self.getBinDir();
+pub fn getPGHome(b: *Build) []const u8 {
+    b.paths.pg_home = b.paths.pg_home orelse blk: {
+        const bindir = b.getBinDir();
         break :blk std.fs.path.dirname(bindir);
     };
-    return self.paths.pg_home.?;
+    return b.paths.pg_home.?;
 }
 
 fn findPGConfig() []const u8 {
@@ -554,4 +653,35 @@ fn trimWhitespace(s: []const u8) []const u8 {
     while (end > start and std.ascii.isWhitespace(s[end - 1])) : (end -= 1) {}
 
     return s[start..end];
+}
+
+fn resolveLazyPath(b: *Build, root_dir: []const u8, p: ?LazyPath, comptime default: []const u8) ?LazyPath {
+    if (p) |configured_path| {
+        return configured_path;
+    }
+    if (resolvePath(b, root_dir, null, default)) |path| {
+        return .{
+            .cwd_relative = path,
+        };
+    }
+    return null;
+}
+
+fn resolvePath(b: *Build, root_dir: []const u8, p: ?[]const u8, default: []const u8) ?[]const u8 {
+    if (p) |configured_path| {
+        return configured_path;
+    }
+    return b.std_build.pathJoin(&[_][]const u8{ root_dir, default });
+}
+
+inline fn joinSteps(b: *Build, name: []const u8, steps: anytype) Step {
+    var step = Step.init(.{
+        .id = .custom,
+        .name = name,
+        .owner = b.std_build,
+    });
+    inline for (steps) |s| {
+        step.dependOn(s);
+    }
+    return step;
 }


### PR DESCRIPTION
Closes: #56 

Move `PGBuild.target` and `PGBuild.optimize` to `PGBuild.options` struct.

Introduce `PGBuild.modules` struct to load a the exported modules via simple function calls like `pgbuild.modules.pgzx()`.

Rename `Run` to `RunExec` to better indicate what that step does.

Simplify addRegress by removing the RunRegress type.

Introduce `addExtensionLib` to the shared lib to compile without installing it right away. This allows users to modify/use the lib with other targets that are not required to install the extension. For example a check target or build source documentation without linking and installation.

Introduce `Project` to combine the meta-data into a common type that can be used to create the different project resources within the build script. E.g. In order to create build/check/docs only steps one is required to redeclare the extension library to have an independent resource. Using the `Project` type we can use `proj.extensionLib` to create multiple instance of the build configuration (including dependencies).

Update the example build scripts:
- improve structure by pre-declaring build steps
- Use new `Project` type.
- Add `zig build check` command that compiles and type checks, but ommits LLVM and linking. Use with ZLS to improve developer experience like: https://kristoff.it/blog/improving-your-zls-experience/