### PR TITLE
pgbuild: make meson patch optional

### DIFF
--- a/dev/bin/pgbuild
+++ b/dev/bin/pgbuild
@@ -93,8 +93,6 @@ EOF
 configure() {
 	echo "Configuring postgres build"
 
-	patch
-
 	meson setup "$PG_BUILD_DIR" "$PG_SRC_DIR" \
 		--debug \
 		-Dprefix="${PG_INSTALL_DIR}" \


### PR DESCRIPTION
postgres sources have been updated with a fix to the meson configuration. We do not need to apply our patch anymore. We still keep `patch` for users with older sources, but will not call that function anymore in the `configure` step.