### PR TITLE
Add missing file in zon file

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,5 +4,6 @@
     .paths = .{
         "build.zig",
         "src",
+        "tools/gennodetags/main.zig",
     },
 }


### PR DESCRIPTION
The build system requires the `tools/gennodetags/main.zig` file, but since it's not included in the `build.zig.zon` file, anyone who adds `pgzx` as a dependency via `zig fetch` (or by specifying the url) will not be able to build their extension. It will fail with the following error: `error: unable to load '/home/guacs/.cache/zig/p/122078a0d7c7c1fc0cee07a61e8101509799873e1f46da165084cd9897f59303652b/tools/gennodetags/main.zig': FileNotFound`

As a workaround, copying the `tools` directory manually to the directory containing the source code that `zig` internally creates will work.