### PR TITLE
collections: add helpers to convert List to zig slice

### DIFF
--- a/src/pgzx.zig
+++ b/src/pgzx.zig
@@ -14,6 +14,7 @@ pub const bgworker = @import("pgzx/bgworker.zig");
 
 pub const collections = @import("pgzx/collections.zig");
 pub const PointerListOf = collections.list.PointerListOf;
+pub const listItemsOf = collections.list.listItemsOf;
 pub const SList = collections.slist.SList;
 pub const DList = collections.dlist.DList;
 pub const HTab = collections.htab.HTab;

--- a/src/pgzx/collections/list.zig
+++ b/src/pgzx/collections/list.zig
@@ -27,6 +27,10 @@ pub fn PointerListOf(comptime T: type) type {
             return Self{ .list = from };
         }
 
+        pub fn itemsOf(list: ?*pg.List) []*T {
+            return Self.initFrom(list).items();
+        }
+
         pub fn init1(v: *T) Self {
             return Self.initFrom(pg.list_make1_impl(
                 pg.T_List,
@@ -211,6 +215,10 @@ pub fn PointerListOf(comptime T: type) type {
             return Self.initFrom(pg.list_difference_ptr(self.list, other.list));
         }
     };
+}
+
+pub fn listItemsOf(comptime T: type, list: ?*pg.List) []*T {
+    return PointerListOf(T).initFrom(list).items();
 }
 
 pub fn IteratorOf(comptime T: type) type {


### PR DESCRIPTION
Add `pgzx.listItemsOf` and `pgzx.collections.list.List.itemsOf` convenience helpers to make it easier to convert a postgres `List` to a Zig based typed slice.