### PR TITLE
Use palloc0() instead of palloc0fast()

### DIFF
--- a/src/pgzx/node.zig
+++ b/src/pgzx/node.zig
@@ -39,7 +39,7 @@ pub inline fn boolVal(node: anytype) bool {
 }
 
 pub inline fn make(comptime T: type) *T {
-    const node: *pg.Node = @ptrCast(@alignCast(pg.palloc0fast(@sizeOf(T))));
+    const node: *pg.Node = @ptrCast(@alignCast(pg.palloc0(@sizeOf(T))));
     node.*.type = @intFromEnum(mustFindTag(T));
     return @ptrCast(@alignCast(node));
 }


### PR DESCRIPTION
The `palloc0fast()` function was removed in PostgreSQL 17 since it according to the PostgreSQL developers was not actually faster than `palloc0()` on modern compilers. So to support PostgreSQL 17 and later we should switch to using `palloc0()`.

See https://git.postgresql.org/pg/commitdiff/3c080fb4fad3e1c1e34f74a7b84a443137adc9f2